### PR TITLE
feat: `ADMIN_PASSWORD` env var & conditional setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"url": "https://github.com/Pitu"
 	},
 	"scripts": {
-		"setup": "node src/setup.js && npm run migrate && npm run seed",
+		"setup": "cross-env node src/setup.js && cross-env npm run migrate && cross-env npm run seed",
 		"start": "npm run migrate && nuxt build && cross-env NODE_ENV=production node src/api/structures/Server",
 		"dev": "nodemon src/api/structures/Server",
 		"migrate": "knex migrate:latest",

--- a/src/api/database/seeds/initial.js
+++ b/src/api/database/seeds/initial.js
@@ -33,7 +33,7 @@ exports.seed = async db => {
 		return;
 	}
 	try {
-		const hash = await bcrypt.hash('admin', 10);
+		const hash = await bcrypt.hash(process.env.ADMIN_PASSWORD, 10);
 		await db.table('users').insert({
 			username: 'admin',
 			password: hash,

--- a/src/setup.js
+++ b/src/setup.js
@@ -12,61 +12,74 @@ async function start() {
 	console.log('You can manually edit .env file after the wizard to edit values');
 	console.log();
 
-	const wizard = [
-		{
-			type: 'input',
-			query: 'Full domain this instance is gonna be running on (Ex: https://my-super-chibisafe.xyz):',
-			handle: 'DOMAIN'
-		},
-		{
-			type: 'input',
-			query: 'Port to run chibisafe in? (default: 5000)',
-			handle: 'SERVER_PORT'
-		},
-		{
-			type: 'interactive',
-			query: 'Which database do you want to use? (select sqlite3 if not sure)',
-			handle: 'DB_CLIENT',
-			symbol: '>',
-			menu: [
-				'sqlite3',
-				'pg',
-				'mysql'
-			]
-		},
-		{
+	const { DOMAIN } = await qoa.input({
+		query: 'Full domain this instance is gonna be running on (Ex: https://my-super-chibisafe.xyz):',
+		handle: 'DOMAIN'
+	});
+
+	const { SERVER_PORT } = await qoa.input({
+		query: 'Port to run chibisafe in? (default: 5000)',
+		handle: 'SERVER_PORT'
+	});
+
+	const { ADMIN_PASSWORD } = await qoa.input({
+		query: 'Default admin account password (default: "admin"):',
+		handle: 'ADMIN_PASSWORD'
+	});
+
+	const { DB_CLIENT } = await qoa.interactive({
+		query: 'Which database do you want to use? (select sqlite3 if not sure)',
+		handle: 'DB_CLIENT',
+		symbol: '>',
+		menu: [
+			'sqlite3',
+			'pg',
+			'mysql'
+		]
+	});
+
+	const dbOpts = {};
+	if (DB_CLIENT !== 'sqlite3') {
+		const { DB_HOST } = await qoa.input({
 			type: 'input',
 			query: 'Database host (Leave blank if you selected sqlite3):',
 			handle: 'DB_HOST'
-		},
-		{
+		});
+		Reflect.set(dbOpts, 'DB_HOST', DB_HOST);
+
+		const { DB_USER } = await qoa.input({
 			type: 'input',
 			query: 'Database user (Leave blank if you selected sqlite3):',
 			handle: 'DB_USER'
-		},
-		{
+		});
+		Reflect.set(dbOpts, 'DB_USER', DB_USER);
+
+		const { DB_PASSWORD } = await qoa.input({
 			type: 'input',
 			query: 'Database password (Leave blank if you selected sqlite3):',
 			handle: 'DB_PASSWORD'
-		},
-		{
+		});
+		Reflect.set(dbOpts, 'DB_PASSWORD', DB_PASSWORD);
+
+		const { DB_DATABASE } = await qoa.input({
 			type: 'input',
 			query: 'Database name (Leave blank if you selected sqlite3):',
 			handle: 'DB_DATABASE'
-		}
-	];
+		});
+		Reflect.set(dbOpts, 'DB_DATABASE', DB_DATABASE);
+	}
 
-	const response = await qoa.prompt(wizard);
 	let envfile = '';
 
 	const defaultSettings = {
-		DOMAIN: response.DOMAIN,
-		SERVER_PORT: response.SERVER_PORT || 5000,
-		DB_CLIENT: response.DB_CLIENT,
-		DB_HOST: response.DB_HOST || null,
-		DB_USER: response.DB_USER || null,
-		DB_PASSWORD: response.DB_PASSWORD || null,
-		DB_DATABASE: response.DB_DATABASE || null
+		DOMAIN,
+		SERVER_PORT: SERVER_PORT || 5000,
+		ADMIN_PASSWORD: ADMIN_PASSWORD || 'admin',
+		DB_CLIENT,
+		DB_HOST: dbOpts.DB_HOST || null,
+		DB_USER: dbOpts.DB_USER || null,
+		DB_PASSWORD: dbOpts.DB_PASSWORD || null,
+		DB_DATABASE: dbOpts.DB_DATABASE || null
 	};
 
 	const keys = Object.keys(defaultSettings);


### PR DESCRIPTION
This PR: 
- adds (and [supports](https://github.com/WeebDev/chibisafe/blob/master/docker/docker-compose.config.example.yml#L9)) the env var `ADMIN_PASSWORD` and creates a prompt within setup
- uses conditional prompting in setup depending on database selection (see below)

db = sqlite3
![image](https://user-images.githubusercontent.com/45381083/146989715-568e8bd8-097a-478d-bcb0-69f30a6c4dd6.png)

db != sqlite3
![image](https://user-images.githubusercontent.com/45381083/146989786-a368f0f7-6774-4cfa-a1f8-ec538a0e6e94.png)
