### PR TITLE
Specify node interpreter to be a confirmed supported version

### DIFF
--- a/pm2.json
+++ b/pm2.json
@@ -2,6 +2,7 @@
 	"apps": [
 		{
 			"name": "chibisafe",
+			"interpreter": "node@14.17.0",
 			"script": "npm",
 			"args": "run start",
 			"env": {


### PR DESCRIPTION
After troubleshooting an issue with Nuxt "ERR_PACKAGE_PATH_NOT_EXPORTED" error with Kana,
they suggested I'd use a "supported" Node version, 14.17.0.

Given installation works with it, I'm requesting this change to be merged to the pm2.json
so it'd be automatically the solution to use by other users.