### PR TITLE
feature/hyper-express <- upload v2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
 				"fluent-ffmpeg": "^2.1.2",
 				"fs-jetpack": "^4.3.1",
 				"helmet": "^5.1.0",
-				"hyper-express": "^6.4.2",
+				"hyper-express": "^6.4.10",
 				"jsonwebtoken": "^8.5.1",
 				"live-directory": "^2.3.2",
 				"moment": "^2.29.4",
@@ -3645,9 +3645,9 @@
 			"dev": true
 		},
 		"node_modules/hyper-express": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.2.tgz",
-			"integrity": "sha512-R4cvUrdDYpulzer6GShRVZQs6V69HRwkV28Y+e3YnSMh2nYf0ipvCmCbOOKbcecUs64cNbY49hujht/njYAgLw==",
+			"version": "6.4.10",
+			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.10.tgz",
+			"integrity": "sha512-lrYfWdkYWmmgQD/96GPd0DsRSxeeTOrvD0DphR+8qHCtyB377orfxZj/9ZxPmvT7/d4jY92EYR2tdVpTUOCD9A==",
 			"dependencies": {
 				"@types/busboy": "^0.3.1",
 				"@types/express": "^4.17.13",
@@ -3657,7 +3657,6 @@
 				"cookie": "^0.4.1",
 				"cookie-signature": "^1.1.0",
 				"mime-types": "^2.1.33",
-				"qs": "^6.10.3",
 				"range-parser": "^1.2.1",
 				"type-is": "^1.6.18",
 				"uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.10.0"
@@ -4650,6 +4649,7 @@
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
 			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -5116,20 +5116,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-			"dependencies": {
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -5622,6 +5608,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -9123,9 +9110,9 @@
 			"dev": true
 		},
 		"hyper-express": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.2.tgz",
-			"integrity": "sha512-R4cvUrdDYpulzer6GShRVZQs6V69HRwkV28Y+e3YnSMh2nYf0ipvCmCbOOKbcecUs64cNbY49hujht/njYAgLw==",
+			"version": "6.4.10",
+			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.10.tgz",
+			"integrity": "sha512-lrYfWdkYWmmgQD/96GPd0DsRSxeeTOrvD0DphR+8qHCtyB377orfxZj/9ZxPmvT7/d4jY92EYR2tdVpTUOCD9A==",
 			"requires": {
 				"@types/busboy": "^1.5.0",
 				"@types/express": "^4.17.13",
@@ -9135,7 +9122,6 @@
 				"cookie": "^0.4.1",
 				"cookie-signature": "^1.1.0",
 				"mime-types": "^2.1.33",
-				"qs": "^6.10.3",
 				"range-parser": "^1.2.1",
 				"type-is": "^1.6.18",
 				"uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.10.0"
@@ -9886,7 +9872,8 @@
 		"object-inspect": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -10237,14 +10224,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-			"requires": {
-				"side-channel": "^1.0.4"
-			}
-		},
 		"queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10574,6 +10553,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,7 @@
 		"fluent-ffmpeg": "^2.1.2",
 		"fs-jetpack": "^4.3.1",
 		"helmet": "^5.1.0",
-		"hyper-express": "^6.4.2",
+		"hyper-express": "^6.4.10",
 		"jsonwebtoken": "^8.5.1",
 		"live-directory": "^2.3.2",
 		"moment": "^2.29.4",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -101,6 +101,16 @@ const start = async () => {
 	server.get('/*', Serve);
 	server.head('/*', Serve);
 
+	// Essentially unused for GET and HEAD due to Serve's handlers
+	server.set_not_found_handler((req: Request, res: Response) => {
+		res.status(404).send('Not found');
+	});
+
+	server.set_error_handler((req: Request, res: Response, error: Error) => {
+		log.error(error);
+		res.status(500).send('Internal server error');
+	});
+
 	// Start the server
 	await server.listen(8000);
 	log.info('');

--- a/backend/src/structures/interfaces.ts
+++ b/backend/src/structures/interfaces.ts
@@ -42,8 +42,8 @@ export interface FileInProgress {
 	size: number;
 	hash: string;
 	ip: string;
+	field?: string;
 	chunksData?: ChunksData;
-	promise?: Promise<void>;
 }
 
 export interface File {


### PR DESCRIPTION
This also updates Hyper-Express to latest (6.4.10) as I discovered a "workaround"
I don't even know why a workaround is necessary, but alas

Gist of the change is what I described in Discord, which is, incoming upload streams will always be stored to disk first
Validations are deferred until all the multipart field(s) have been processed

I experimented with "consuming the streams into the void", or something of that nature, but I failed to make any breakthroughs
So had to settle with actually storing to disk

In practice, files that previously would have been accepted just fine, should still behave the same