### PR TITLE
[Feature] Add custom domain and mixed case filenames

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -202,10 +202,12 @@ const start = async () => {
 		});
 	}
 
-	// Serve uploads
-	await server.register(fstatic, {
-		root: path.join(__dirname, '..', '..', '..', 'uploads')
-	});
+	// Serve uploads only if the user didn't change the default value
+	if (!SETTINGS.serveUploadsFrom) {
+		await server.register(fstatic, {
+			root: path.join(__dirname, '..', '..', '..', 'uploads')
+		});
+	}
 
 	// Start the server
 	await server.listen({ port: Number(SETTINGS.port), host: SETTINGS.host as string });
@@ -226,7 +228,7 @@ export const getHtmlBuffer = async () => {
 	indexHTML = indexHTML.replaceAll('{{description}}', SETTINGS.metaDescription);
 	indexHTML = indexHTML.replaceAll('{{keywords}}', SETTINGS.metaKeywords);
 	indexHTML = indexHTML.replaceAll('{{twitter}}', SETTINGS.metaTwitterHandle);
-	indexHTML = indexHTML.replaceAll('{{domain}}', SETTINGS.domain);
+	indexHTML = indexHTML.replaceAll('{{domain}}', SETTINGS.metaDomain);
 
 	const settings = {
 		backgroundImageURL: SETTINGS.backgroundImageURL,

--- a/packages/backend/src/prisma/migrations/20230629002506_add_path_and_mixed_case_settings/migration.sql
+++ b/packages/backend/src/prisma/migrations/20230629002506_add_path_and_mixed_case_settings/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `domain` on the `settings` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_settings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "rateLimitWindow" INTEGER NOT NULL,
+    "rateLimitMax" INTEGER NOT NULL,
+    "secret" TEXT NOT NULL,
+    "serviceName" TEXT NOT NULL,
+    "chunkSize" TEXT NOT NULL,
+    "chunkedUploadsTimeout" INTEGER NOT NULL,
+    "maxSize" TEXT NOT NULL,
+    "generateZips" BOOLEAN NOT NULL,
+    "generatedFilenameLength" INTEGER NOT NULL,
+    "generatedAlbumLength" INTEGER NOT NULL,
+    "blockedExtensions" TEXT NOT NULL,
+    "blockNoExtension" BOOLEAN NOT NULL,
+    "publicMode" BOOLEAN NOT NULL,
+    "userAccounts" BOOLEAN NOT NULL,
+    "disableStatisticsCron" BOOLEAN NOT NULL,
+    "backgroundImageURL" TEXT NOT NULL,
+    "logoURL" TEXT NOT NULL,
+    "metaDescription" TEXT NOT NULL,
+    "metaKeywords" TEXT NOT NULL,
+    "metaTwitterHandle" TEXT NOT NULL,
+    "metaDomain" TEXT NOT NULL DEFAULT '',
+    "serveUploadsFrom" TEXT NOT NULL DEFAULT '',
+    "enableMixedCaseFilenames" BOOLEAN NOT NULL DEFAULT true
+);
+INSERT INTO "new_settings" ("backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "id", "logoURL", "maxSize", "metaDescription", "metaKeywords", "metaTwitterHandle", "publicMode", "rateLimitMax", "rateLimitWindow", "secret", "serviceName", "userAccounts") SELECT "backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "id", "logoURL", "maxSize", "metaDescription", "metaKeywords", "metaTwitterHandle", "publicMode", "rateLimitMax", "rateLimitWindow", "secret", "serviceName", "userAccounts" FROM "settings";
+DROP TABLE "settings";
+ALTER TABLE "new_settings" RENAME TO "settings";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -75,7 +75,6 @@ model links {
 
 model settings {
 	id Int @id @default(autoincrement())
-	domain String
 	rateLimitWindow Int
 	rateLimitMax Int
 	secret String
@@ -96,6 +95,9 @@ model settings {
 	metaDescription String
 	metaKeywords String
 	metaTwitterHandle String
+	metaDomain String @default("")
+	serveUploadsFrom String @default("")
+	enableMixedCaseFilenames Boolean @default(true)
 }
 
 model statistics {

--- a/packages/backend/src/routes/admin/files/GetFile.ts
+++ b/packages/backend/src/routes/admin/files/GetFile.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 import type { User, RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 
 export const options = {
@@ -59,7 +59,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const extendedFile = {
 		...file,
-		...constructFilePublicLinkNew(req, file.name)
+		...constructFilePublicLink(req, file.name)
 	};
 
 	return res.send({

--- a/packages/backend/src/routes/admin/files/GetFile.ts
+++ b/packages/backend/src/routes/admin/files/GetFile.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 import type { User, RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 
 export const options = {
@@ -57,7 +57,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		}
 	}
 
-	const extendedFile = constructFilePublicLink(req, file);
+	const extendedFile = {
+		...file,
+		...constructFilePublicLinkNew(req, file.name)
+	};
 
 	return res.send({
 		message: 'Successfully retrieved file',

--- a/packages/backend/src/routes/admin/files/GetFiles.ts
+++ b/packages/backend/src/routes/admin/files/GetFiles.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from 'fastify';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 
 export const options = {
 	url: '/admin/files',
@@ -66,7 +66,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const readyFiles = [];
 	for (const file of files) {
-		readyFiles.push(constructFilePublicLink(req, file));
+		readyFiles.push({
+			...file,
+			...constructFilePublicLinkNew(req, file.name)
+		});
 	}
 
 	return res.send({

--- a/packages/backend/src/routes/admin/files/GetFiles.ts
+++ b/packages/backend/src/routes/admin/files/GetFiles.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from 'fastify';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 
 export const options = {
 	url: '/admin/files',
@@ -68,7 +68,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLinkNew(req, file.name)
+			...constructFilePublicLink(req, file.name)
 		});
 	}
 

--- a/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
+++ b/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 
 export const options = {
@@ -34,7 +34,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLinkNew(req, file.name)
+			...constructFilePublicLink(req, file.name)
 		});
 	}
 

--- a/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
+++ b/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 
 export const options = {
@@ -32,7 +32,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const readyFiles = [];
 	for (const file of files) {
-		readyFiles.push(constructFilePublicLink(req, file));
+		readyFiles.push({
+			...file,
+			...constructFilePublicLinkNew(req, file.name)
+		});
 	}
 
 	const checkForBan = await prisma.bans.findFirst({

--- a/packages/backend/src/routes/admin/users/GetUser.ts
+++ b/packages/backend/src/routes/admin/users/GetUser.ts
@@ -1,6 +1,5 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
 
 export const options = {
 	url: '/admin/user/:uuid',

--- a/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
+++ b/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
@@ -1,7 +1,7 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { ExtendedFile } from '@/structures/interfaces';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 
 export const options = {
 	url: '/admin/user/:uuid/files',
@@ -73,7 +73,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLinkNew(req, file.name)
+			...constructFilePublicLink(req, file.name)
 		});
 	}
 

--- a/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
+++ b/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
@@ -1,7 +1,7 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { ExtendedFile } from '@/structures/interfaces';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 
 export const options = {
 	url: '/admin/user/:uuid/files',
@@ -71,7 +71,10 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 
 	const readyFiles = [];
 	for (const file of files) {
-		readyFiles.push(constructFilePublicLink(req, file));
+		readyFiles.push({
+			...file,
+			...constructFilePublicLinkNew(req, file.name)
+		});
 	}
 
 	return res.send({

--- a/packages/backend/src/routes/album/GetAlbum.ts
+++ b/packages/backend/src/routes/album/GetAlbum.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 import type { File, RequestWithUser } from '@/structures/interfaces';
 
 export const options = {
@@ -57,7 +57,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const files = [] as File[];
 	for (const file of album.files) {
 		const modifiedFile = file as unknown as File;
-		files.push(constructFilePublicLink(req, modifiedFile));
+		files.push({
+			...modifiedFile,
+			...constructFilePublicLinkNew(req, modifiedFile.name)
+		});
 	}
 
 	return res.send({

--- a/packages/backend/src/routes/album/GetAlbum.ts
+++ b/packages/backend/src/routes/album/GetAlbum.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 import type { File, RequestWithUser } from '@/structures/interfaces';
 
 export const options = {
@@ -59,7 +59,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		const modifiedFile = file as unknown as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLinkNew(req, modifiedFile.name)
+			...constructFilePublicLink(req, modifiedFile.name)
 		});
 	}
 

--- a/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
+++ b/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 import type { File } from '@/structures/interfaces';
 
 export const options = {
@@ -72,7 +72,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 		const modifiedFile = file as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLinkNew(req, modifiedFile.name)
+			...constructFilePublicLink(req, modifiedFile.name)
 		});
 	}
 

--- a/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
+++ b/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 import type { File } from '@/structures/interfaces';
 
 export const options = {
@@ -70,7 +70,10 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 	const files = [] as File[];
 	for (const file of album.files) {
 		const modifiedFile = file as File;
-		files.push(constructFilePublicLink(req, modifiedFile));
+		files.push({
+			...modifiedFile,
+			...constructFilePublicLinkNew(req, modifiedFile.name)
+		});
 	}
 
 	await prisma.links.update({

--- a/packages/backend/src/routes/album/GetAlbums.ts
+++ b/packages/backend/src/routes/album/GetAlbums.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
 import type { RequestWithUser, Album } from '@/structures/interfaces';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 
 export const options = {
 	url: '/albums',
@@ -56,7 +56,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		delete newObject._count;
 
 		newObject.cover = album.files[0]
-			? constructFilePublicLinkNew(req, album.files[0].name as unknown as any).thumbSquare
+			? constructFilePublicLink(req, album.files[0].name as unknown as any).thumbSquare
 			: '';
 		fetchedAlbums.push(newObject);
 	}

--- a/packages/backend/src/routes/album/GetAlbums.ts
+++ b/packages/backend/src/routes/album/GetAlbums.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
 import type { RequestWithUser, Album } from '@/structures/interfaces';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 
 export const options = {
 	url: '/albums',
@@ -56,7 +56,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		delete newObject._count;
 
 		newObject.cover = album.files[0]
-			? constructFilePublicLink(req, album.files[0] as unknown as any).thumbSquare
+			? constructFilePublicLinkNew(req, album.files[0].name as unknown as any).thumbSquare
 			: '';
 		fetchedAlbums.push(newObject);
 	}

--- a/packages/backend/src/routes/auth/Login.ts
+++ b/packages/backend/src/routes/auth/Login.ts
@@ -9,7 +9,7 @@ export const options = {
 	method: 'post',
 	options: {
 		rateLimit: {
-			max: 3, // Three rquests
+			max: 10, // Ten rquests
 			timeWindow: 1000 * 60 // Per minute
 		}
 	}

--- a/packages/backend/src/routes/auth/Register.ts
+++ b/packages/backend/src/routes/auth/Register.ts
@@ -11,7 +11,7 @@ export const options = {
 	method: 'post',
 	options: {
 		rateLimit: {
-			max: 3, // Three rquests
+			max: 10, // Ten rquests
 			timeWindow: 1000 * 60 // Per minute
 		}
 	}

--- a/packages/backend/src/routes/files/GetFile.ts
+++ b/packages/backend/src/routes/files/GetFile.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 import type { ExtendedFile, RequestWithUser } from '@/structures/interfaces';
 
 export const options = {
@@ -47,7 +47,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	// Build the public links
 	let parsedFile: ExtendedFile = file;
-	parsedFile = constructFilePublicLink(req, file);
+	parsedFile = {
+		...file,
+		...constructFilePublicLinkNew(req, file.name)
+	};
 
 	return res.send({
 		message: 'Successfully retrieved file',

--- a/packages/backend/src/routes/files/GetFile.ts
+++ b/packages/backend/src/routes/files/GetFile.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 import type { ExtendedFile, RequestWithUser } from '@/structures/interfaces';
 
 export const options = {
@@ -49,7 +49,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	let parsedFile: ExtendedFile = file;
 	parsedFile = {
 		...file,
-		...constructFilePublicLinkNew(req, file.name)
+		...constructFilePublicLink(req, file.name)
 	};
 
 	return res.send({

--- a/packages/backend/src/routes/files/GetFiles.ts
+++ b/packages/backend/src/routes/files/GetFiles.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 
 export const options = {
@@ -44,7 +44,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLinkNew(req, file.name)
+			...constructFilePublicLink(req, file.name)
 		});
 	}
 

--- a/packages/backend/src/routes/files/GetFiles.ts
+++ b/packages/backend/src/routes/files/GetFiles.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
 
 export const options = {
@@ -42,7 +42,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const readyFiles = [];
 	for (const file of files) {
-		readyFiles.push(constructFilePublicLink(req, file));
+		readyFiles.push({
+			...file,
+			...constructFilePublicLinkNew(req, file.name)
+		});
 	}
 
 	return res.send({

--- a/packages/backend/src/routes/files/Search.ts
+++ b/packages/backend/src/routes/files/Search.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
-import { constructFilePublicLink } from '@/utils/File';
+import { constructFilePublicLinkNew } from '@/utils/File';
 
 export const options = {
 	url: '/files/search',
@@ -85,7 +85,10 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const readyFiles = [];
 	for (const file of files) {
-		readyFiles.push(constructFilePublicLink(req, file));
+		readyFiles.push({
+			...file,
+			...constructFilePublicLinkNew(req, file.name)
+		});
 	}
 
 	return res.send({

--- a/packages/backend/src/routes/files/Search.ts
+++ b/packages/backend/src/routes/files/Search.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database';
 import type { RequestWithUser, ExtendedFile } from '@/structures/interfaces';
-import { constructFilePublicLinkNew } from '@/utils/File';
+import { constructFilePublicLink } from '@/utils/File';
 
 export const options = {
 	url: '/files/search',
@@ -87,7 +87,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLinkNew(req, file.name)
+			...constructFilePublicLink(req, file.name)
 		});
 	}
 

--- a/packages/backend/src/routes/files/Upload.ts
+++ b/packages/backend/src/routes/files/Upload.ts
@@ -9,7 +9,6 @@ import { SETTINGS } from '@/structures/settings';
 import {
 	getUniqueFileIdentifier,
 	storeFileToDb,
-	constructFilePublicLink,
 	constructFilePublicLinkNew,
 	hashFile,
 	checkFileHashOnDB,

--- a/packages/backend/src/routes/files/Upload.ts
+++ b/packages/backend/src/routes/files/Upload.ts
@@ -9,7 +9,7 @@ import { SETTINGS } from '@/structures/settings';
 import {
 	getUniqueFileIdentifier,
 	storeFileToDb,
-	constructFilePublicLinkNew,
+	constructFilePublicLink,
 	hashFile,
 	checkFileHashOnDB,
 	deleteTmpFile
@@ -98,7 +98,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			void generateThumbnails(savedFile.file.name);
 		}
 
-		const linkData = constructFilePublicLinkNew(req, uploadedFile.name);
+		const linkData = constructFilePublicLink(req, uploadedFile.name);
 		// Construct public link
 		const fileWithLink = {
 			...uploadedFile,

--- a/packages/backend/src/structures/interfaces.ts
+++ b/packages/backend/src/structures/interfaces.ts
@@ -94,7 +94,7 @@ export interface Album {
 
 export interface Settings {
 	port: number;
-	domain: string;
+	metaDomain: string;
 	rateLimitWindow: number;
 	rateLimitMax: number;
 	secret: string;
@@ -117,6 +117,8 @@ export interface Settings {
 	statisticsCron: string;
 	disableStatisticsCron: boolean;
 	enabledStatistics: string[];
+	serveUploadsFrom: string;
+	enableMixedCaseFilenames: boolean;
 	// savedStatistics: string[];
 	[key: string]: string[] | boolean | number | string;
 }

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -33,15 +33,16 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.enabledStatistics = ['system', 'service', 'fileSystems', 'uploads', 'users', 'albums'];
 
 		// These settings should be set from the database
-		SETTINGS.domain = settingsTable.domain;
+		SETTINGS.serviceName = settingsTable.serviceName;
+		SETTINGS.serveUploadsFrom = settingsTable.serveUploadsFrom;
 		SETTINGS.rateLimitWindow = settingsTable.rateLimitWindow;
 		SETTINGS.rateLimitMax = settingsTable.rateLimitMax;
 		SETTINGS.secret = settingsTable.secret;
-		SETTINGS.serviceName = settingsTable.serviceName;
 		SETTINGS.chunkSize = Number(settingsTable.chunkSize);
 		SETTINGS.chunkedUploadsTimeout = settingsTable.chunkedUploadsTimeout;
 		SETTINGS.maxSize = Number(settingsTable.maxSize);
 		SETTINGS.generateZips = settingsTable.generateZips;
+		SETTINGS.enableMixedCaseFilenames = settingsTable.enableMixedCaseFilenames;
 		SETTINGS.generatedFilenameLength = settingsTable.generatedFilenameLength;
 		SETTINGS.generatedAlbumLength = settingsTable.generatedAlbumLength;
 		SETTINGS.blockedExtensions = JSON.parse(settingsTable.blockedExtensions);
@@ -54,21 +55,23 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.metaDescription = settingsTable.metaDescription;
 		SETTINGS.metaKeywords = settingsTable.metaKeywords;
 		SETTINGS.metaTwitterHandle = settingsTable.metaTwitterHandle;
+		SETTINGS.metaDomain = settingsTable.metaDomain;
 		return;
 	}
 
 	// if SETTINGS is empty and there is no database entry, create it
 	log.debug("Settings don't exist in database, creating...");
 	const data = {
-		domain: 'localhost:8000',
 		rateLimitWindow: 1000,
 		rateLimitMax: 100,
 		secret: randomstring.generate(64),
 		serviceName: 'change-me',
+		serveUploadsFrom: '',
 		chunkSize: 9 * 9e6, // 90 MB
 		chunkedUploadsTimeout: 30 * 60 * 1000, // 30 minutes
 		maxSize: 1 * 1e9, // 1 GB
 		generateZips: true,
+		enableMixedCaseFilenames: true,
 		generatedFilenameLength: 12,
 		generatedAlbumLength: 6,
 		blockedExtensions: JSON.stringify(['.jar', '.exe', '.msi', '.com', '.bat', '.cmd', '.scr', '.ps1', '.sh']),
@@ -78,6 +81,7 @@ export const loadSettings = async (force = false) => {
 		disableStatisticsCron: false,
 		backgroundImageURL: '',
 		logoURL: '',
+		metaDomain: 'https://your-domain.com',
 		metaDescription: 'description for please-change-me.com 🚀',
 		metaKeywords: 'comma, separated, keywords, that, describe, this, website',
 		metaTwitterHandle: '@your-twitter-handle'
@@ -108,11 +112,13 @@ const SETTINGS_META = {
 		description: 'The host the server will listen on.',
 		name: 'Host'
 	},
-	domain: {
+	serveUploadsFrom: {
 		type: 'string',
-		description: 'The domain the server will be hosted on.',
-		name: 'Domain',
-		example: 'https://chibisafe.moe'
+		description:
+			'Fill this if you want to serve your files from a custom domain with nginx/caddy. Leave empty to let chibisafe handle it.',
+		name: 'Serve Uploads From',
+		example: 'https://cdn.chibisafe.moe',
+		notice: 'For this setting to take effect, you need to restart the server.'
 	},
 	rateLimitWindow: {
 		type: 'number',
@@ -162,6 +168,11 @@ const SETTINGS_META = {
 		type: 'boolean',
 		description: 'Whether or not to allow users to generate zips from public albums.',
 		name: 'Generate Zips'
+	},
+	enableMixedCaseFilenames: {
+		type: 'boolean',
+		description: 'Whether to allow mixed case filenames.',
+		name: 'Enable Mixed Case Filenames'
 	},
 	generatedFilenameLength: {
 		type: 'number',
@@ -213,21 +224,27 @@ const SETTINGS_META = {
 		description: 'The URL for the logo.',
 		name: 'Logo URL'
 	},
+	domain: {
+		type: 'string',
+		description: 'The meta domain used for the website SEO.',
+		name: 'Meta Domain',
+		example: 'https://chibisafe.moe'
+	},
 	metaDescription: {
 		type: 'string',
-		description: 'The meta description for the website.',
+		description: 'The meta description for the website SEO.',
 		name: 'Meta Description',
 		example: 'A simple and easy to use file hosting service.'
 	},
 	metaKeywords: {
 		type: 'string',
-		description: 'The meta keywords for the website.',
+		description: 'The meta keywords for the website SEO.',
 		name: 'Meta Keywords',
 		example: 'file, hosting, service'
 	},
 	metaTwitterHandle: {
 		type: 'string',
-		description: 'The twitter handle for the website.',
+		description: 'The twitter handle of the instance owner.',
 		name: 'Meta Twitter Handle',
 		example: '@chibisafe'
 	}

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -224,7 +224,7 @@ const SETTINGS_META = {
 		description: 'The URL for the logo.',
 		name: 'Logo URL'
 	},
-	domain: {
+	metaDomain: {
 		type: 'string',
 		description: 'The meta domain used for the website SEO.',
 		name: 'Meta Domain',

--- a/packages/backend/src/utils/File.ts
+++ b/packages/backend/src/utils/File.ts
@@ -182,20 +182,6 @@ export const constructFilePublicLinkNew = (req: FastifyRequest, fileName: string
 	return data;
 };
 
-export const constructFilePublicLink = (req: FastifyRequest, file: File) => {
-	const extended: ExtendedFile = { ...file };
-	const host = getHost(req);
-	extended.url = `${host}/${extended.name}`;
-	const { thumb, preview } = getFileThumbnail(extended.name) ?? {};
-	if (thumb) {
-		extended.thumb = `${host}/thumbs/${thumb}`;
-		extended.thumbSquare = `${host}/thumbs/square/${thumb}`;
-		extended.preview = preview && `${host}/thumbs/preview/${preview}`;
-	}
-
-	return extended;
-};
-
 export const checkFileHashOnDB = async (user: RequestUser | User | undefined, file: FileInProgress) => {
 	const dbFile = await prisma.files.findFirst({
 		where: {

--- a/packages/backend/src/utils/File.ts
+++ b/packages/backend/src/utils/File.ts
@@ -161,7 +161,7 @@ export const createZip = (files: string[], albumUuid: string) => {
 	}
 };
 
-export const constructFilePublicLinkNew = (req: FastifyRequest, fileName: string) => {
+export const constructFilePublicLink = (req: FastifyRequest, fileName: string) => {
 	const host = getHost(req);
 	const data = {
 		url: `${host}/${fileName}`,

--- a/packages/backend/src/utils/File.ts
+++ b/packages/backend/src/utils/File.ts
@@ -162,7 +162,7 @@ export const createZip = (files: string[], albumUuid: string) => {
 };
 
 export const constructFilePublicLink = (req: FastifyRequest, fileName: string) => {
-	const host = getHost(req);
+	const host = SETTINGS.serveUploadsFrom ? SETTINGS.serveUploadsFrom : getHost(req);
 	const data = {
 		url: `${host}/${fileName}`,
 		thumb: '',

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -6,7 +6,7 @@
 	</metainfo>
 
 	<div
-		v-if="userStore.user?.id === 1 && !userStore.user.passwordEditedAt"
+		v-if="userStore.user?.username === 'admin' && userStore.user.isAdmin && !userStore.user.passwordEditedAt"
 		class="w-full p-6 flex justify-center items-center text-light-100 bg-red-900"
 	>
 		It seems you are using the admin account but haven't changed the default password yet. Go to the dashboard and


### PR DESCRIPTION
This PR does:
- Adds the possibility of defining a custom domain to serve files from
- Adds the possibility of having mixed case letters in the generated filenames
  - For reference, with only 4 digits you could have 1,679,616 combinations. With mixed case, you could have 14,776,336 combinations
  - On Windows this is turned off by default and can't be changed