### PR TITLE
[Fix] Not able to fetch only anonymous files.

### DIFF
--- a/packages/backend/src/routes/admin/files/GetFiles.ts
+++ b/packages/backend/src/routes/admin/files/GetFiles.ts
@@ -14,7 +14,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		publicOnly = false,
 		page = 1,
 		limit = 50
-	} = req.query as { publicOnly: string; page?: number; limit?: number };
+	} = req.query as { publicOnly: boolean; page?: number; limit?: number };
 
 	const dbSearchObject = {} as any;
 	const dbObject = {
@@ -36,7 +36,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		}
 	} as any;
 
-	if (publicOnly && publicOnly === 'true') {
+	if (publicOnly) {
 		dbSearchObject.where = {
 			userId: null
 		};

--- a/packages/backend/src/structures/schemas/FilesAsAdmin.ts
+++ b/packages/backend/src/structures/schemas/FilesAsAdmin.ts
@@ -35,7 +35,8 @@ export default {
 					description: "The user's creation date.",
 					example: '2021-01-01T00:00:00.000Z'
 				}
-			}
+			},
+			nullable: true
 		}
 	}
 };


### PR DESCRIPTION
Due to the recent addition of route schemas, the `publicOnly` query option was no longer working.