### PR TITLE
[Fix] Only apply rate limits to routes

### DIFF
--- a/packages/backend/src/structures/routes.ts
+++ b/packages/backend/src/structures/routes.ts
@@ -11,6 +11,13 @@ const defaultMiddlewares = ['log', 'ban'];
 
 export default {
 	load: async (server: FastifyInstance) => {
+		// Add global rate limit
+		await server.register(import('@fastify/rate-limit'), {
+			global: true,
+			max: SETTINGS.rateLimitMax,
+			timeWindow: SETTINGS.rateLimitWindow
+		});
+
 		// Different extension for build and dev modes
 		const extension = `${process.env.NODE_ENV === 'production' ? 'j' : 't'}s`;
 


### PR DESCRIPTION
Currently the rate-limit plugin is registered globally which causes it to affect files served through the static plugin. Registering the rate-limit plugin and routes in a scoped server instance to fix this.