### PR TITLE
[Feature] Migrate users to roles

### DIFF
--- a/packages/backend/src/middlewares/admin.ts
+++ b/packages/backend/src/middlewares/admin.ts
@@ -2,7 +2,7 @@ import type { FastifyReply, HookHandlerDoneFunction } from 'fastify';
 import type { RequestWithUser } from '@/structures/interfaces';
 
 export default (req: RequestWithUser, res: FastifyReply, next: HookHandlerDoneFunction) => {
-	if (!req.user?.isAdmin) {
+	if (!req.user?.roles.some(role => role.name === 'admin')) {
 		res.unauthorized('You need to be an admin to access this resource');
 		return;
 	}

--- a/packages/backend/src/middlewares/apiKey.ts
+++ b/packages/backend/src/middlewares/apiKey.ts
@@ -10,6 +10,13 @@ export default async (req: RequestWithUser, res: FastifyReply, next: HookHandler
 	const user = await prisma.users.findFirst({
 		where: {
 			apiKey
+		},
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
 		}
 	});
 
@@ -28,7 +35,7 @@ export default async (req: RequestWithUser, res: FastifyReply, next: HookHandler
 		id: user.id,
 		uuid: user.uuid,
 		username: user.username,
-		isAdmin: user.isAdmin,
+		roles: user.roles,
 		apiKey: user.apiKey,
 		passwordEditedAt: user.passwordEditedAt
 	};

--- a/packages/backend/src/middlewares/auth.ts
+++ b/packages/backend/src/middlewares/auth.ts
@@ -65,9 +65,13 @@ export default (
 				uuid: true,
 				username: true,
 				enabled: true,
-				isAdmin: true,
 				apiKey: true,
-				passwordEditedAt: true
+				passwordEditedAt: true,
+				roles: {
+					select: {
+						name: true
+					}
+				}
 			}
 		});
 
@@ -90,7 +94,7 @@ export default (
 			id: user.id,
 			uuid: user.uuid,
 			username: user.username,
-			isAdmin: user.isAdmin,
+			roles: user.roles,
 			apiKey: user.apiKey,
 			passwordEditedAt: user.passwordEditedAt
 		};

--- a/packages/backend/src/middlewares/owner.ts
+++ b/packages/backend/src/middlewares/owner.ts
@@ -1,0 +1,11 @@
+import type { FastifyReply, HookHandlerDoneFunction } from 'fastify';
+import type { RequestWithUser } from '@/structures/interfaces';
+
+export default (req: RequestWithUser, res: FastifyReply, next: HookHandlerDoneFunction) => {
+	if (!req.user?.roles.some(role => role.name === 'owner')) {
+		res.unauthorized('You need to be the owner of the instance to access this resource');
+		return;
+	}
+
+	next();
+};

--- a/packages/backend/src/prisma/migrations/20230708062855_add_user_roles/migration.sql
+++ b/packages/backend/src/prisma/migrations/20230708062855_add_user_roles/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "roles" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_rolesTousers" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+    CONSTRAINT "_rolesTousers_A_fkey" FOREIGN KEY ("A") REFERENCES "roles" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_rolesTousers_B_fkey" FOREIGN KEY ("B") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "roles_name_key" ON "roles"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_rolesTousers_AB_unique" ON "_rolesTousers"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_rolesTousers_B_index" ON "_rolesTousers"("B");
+
+-- Assign the corresponded roles to the users
+INSERT INTO "roles" ("name") VALUES ('owner');
+INSERT INTO "roles" ("name") VALUES ('admin');
+INSERT INTO "roles" ("name") VALUES ('user');
+INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'admin') FROM "users" WHERE "isAdmin" = true;
+INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'user') FROM "users" WHERE "isAdmin" = false;
+
+-- Grab the first admin user that is not disabled
+-- and assign the owner role to it
+INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'owner') FROM "users" WHERE "isAdmin" = true AND "enabled" = true LIMIT 1;
+
+--- Delete the old isAdmin column from the users table

--- a/packages/backend/src/prisma/migrations/20230708062855_add_user_roles/migration.sql
+++ b/packages/backend/src/prisma/migrations/20230708062855_add_user_roles/migration.sql
@@ -26,10 +26,33 @@ INSERT INTO "roles" ("name") VALUES ('owner');
 INSERT INTO "roles" ("name") VALUES ('admin');
 INSERT INTO "roles" ("name") VALUES ('user');
 INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'admin') FROM "users" WHERE "isAdmin" = true;
-INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'user') FROM "users" WHERE "isAdmin" = false;
+INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'user') FROM "users";
 
 -- Grab the first admin user that is not disabled
 -- and assign the owner role to it
 INSERT INTO "_rolesTousers" ("B", "A") SELECT "id", (SELECT "id" FROM "roles" WHERE "name" = 'owner') FROM "users" WHERE "isAdmin" = true AND "enabled" = true LIMIT 1;
 
 --- Delete the old isAdmin column from the users table
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_users" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "uuid" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "storageQuota" TEXT NOT NULL DEFAULT '0',
+    "apiKey" TEXT,
+    "passwordEditedAt" DATETIME,
+    "apiKeyEditedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "editedAt" DATETIME
+);
+INSERT INTO "new_users" ("apiKey", "apiKeyEditedAt", "createdAt", "editedAt", "enabled", "id", "password", "passwordEditedAt", "storageQuota", "username", "uuid") SELECT "apiKey", "apiKeyEditedAt", "createdAt", "editedAt", "enabled", "id", "password", "passwordEditedAt", "storageQuota", "username", "uuid" FROM "users";
+DROP TABLE "users";
+ALTER TABLE "new_users" RENAME TO "users";
+CREATE UNIQUE INDEX "users_uuid_key" ON "users"("uuid");
+CREATE UNIQUE INDEX "users_username_key" ON "users"("username");
+CREATE UNIQUE INDEX "users_apiKey_key" ON "users"("apiKey");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -23,6 +23,13 @@ model users {
 	createdAt DateTime @default(now())
 	editedAt DateTime?
 	files files[]
+	roles roles[]
+}
+
+model roles {
+	id Int @id @default(autoincrement())
+	name String @unique
+	users users[]
 }
 
 model files {

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -15,7 +15,6 @@ model users {
 	username String @unique
 	password String
 	enabled Boolean @default(true)
-	isAdmin Boolean @default(false)
 	storageQuota String @default("0")
 	apiKey String? @unique
 	passwordEditedAt DateTime?

--- a/packages/backend/src/routes/admin/files/GetFile.ts
+++ b/packages/backend/src/routes/admin/files/GetFile.ts
@@ -44,7 +44,11 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 				enabled: true,
 				createdAt: true,
 				editedAt: true,
-				isAdmin: true
+				roles: {
+					select: {
+						name: true
+					}
+				}
 			}
 		});
 

--- a/packages/backend/src/routes/admin/files/GetFiles.ts
+++ b/packages/backend/src/routes/admin/files/GetFiles.ts
@@ -50,8 +50,12 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 				uuid: true,
 				username: true,
 				enabled: true,
-				isAdmin: true,
-				createdAt: true
+				createdAt: true,
+				roles: {
+					select: {
+						name: true
+					}
+				}
 			}
 		};
 	}

--- a/packages/backend/src/routes/admin/users/Demote.ts
+++ b/packages/backend/src/routes/admin/users/Demote.ts
@@ -5,7 +5,7 @@ import prisma from '@/structures/database';
 export const options = {
 	url: '/admin/user/:uuid/demote',
 	method: 'post',
-	middlewares: ['auth', 'admin']
+	middlewares: ['auth', 'owner']
 };
 
 export const run = async (req: RequestWithUser, res: FastifyReply) => {

--- a/packages/backend/src/routes/admin/users/Demote.ts
+++ b/packages/backend/src/routes/admin/users/Demote.ts
@@ -23,10 +23,17 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const user = await prisma.users.findUnique({
 		where: {
 			uuid
+		},
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
 		}
 	});
 
-	if (!user?.isAdmin) {
+	if (!user?.roles.some(role => role.name === 'admin')) {
 		res.badRequest('User is not an admin');
 		return;
 	}
@@ -36,7 +43,11 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			uuid
 		},
 		data: {
-			isAdmin: false
+			roles: {
+				disconnect: {
+					name: 'admin'
+				}
+			}
 		}
 	});
 

--- a/packages/backend/src/routes/admin/users/Disable.ts
+++ b/packages/backend/src/routes/admin/users/Disable.ts
@@ -23,8 +23,23 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const user = await prisma.users.findUnique({
 		where: {
 			uuid
+		},
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
 		}
 	});
+
+	if (
+		user?.roles.some(role => role.name === 'admin' || role.name === 'owner') &&
+		!req.user.roles.some(role => role.name === 'owner')
+	) {
+		res.badRequest('You cannot disable another admin or owner');
+		return;
+	}
 
 	if (!user?.enabled) {
 		res.badRequest('User is already disabled');

--- a/packages/backend/src/routes/admin/users/Enable.ts
+++ b/packages/backend/src/routes/admin/users/Enable.ts
@@ -23,8 +23,23 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const user = await prisma.users.findUnique({
 		where: {
 			uuid
+		},
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
 		}
 	});
+
+	if (
+		user?.roles.some(role => role.name === 'admin' || role.name === 'owner') &&
+		!req.user.roles.some(role => role.name === 'owner')
+	) {
+		res.badRequest('You cannot enable another admin or owner');
+		return;
+	}
 
 	if (user?.enabled) {
 		res.badRequest('User is already enabled');

--- a/packages/backend/src/routes/admin/users/GetAllUsers.schema.ts
+++ b/packages/backend/src/routes/admin/users/GetAllUsers.schema.ts
@@ -15,7 +15,7 @@ export default {
 							uuid: { $ref: 'UserAsAdmin#/properties/uuid' },
 							username: { $ref: 'UserAsAdmin#/properties/username' },
 							enabled: { $ref: 'UserAsAdmin#/properties/enabled' },
-							isAdmin: { $ref: 'UserAsAdmin#/properties/isAdmin' },
+							roles: { $ref: 'UserAsAdmin#/properties/roles' },
 							createdAt: { $ref: 'UserAsAdmin#/properties/createdAt' },
 							storageQuota: { $ref: 'StorageQuota' },
 							_count: {

--- a/packages/backend/src/routes/admin/users/GetAllUsers.ts
+++ b/packages/backend/src/routes/admin/users/GetAllUsers.ts
@@ -16,7 +16,11 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 			uuid: true,
 			username: true,
 			enabled: true,
-			isAdmin: true,
+			roles: {
+				select: {
+					name: true
+				}
+			},
 			createdAt: true,
 			_count: {
 				select: {

--- a/packages/backend/src/routes/admin/users/GetUser.schema.ts
+++ b/packages/backend/src/routes/admin/users/GetUser.schema.ts
@@ -23,7 +23,7 @@ export default {
 						uuid: { $ref: 'UserAsAdmin#/properties/uuid' },
 						username: { $ref: 'UserAsAdmin#/properties/username' },
 						enabled: { $ref: 'UserAsAdmin#/properties/enabled' },
-						isAdmin: { $ref: 'UserAsAdmin#/properties/isAdmin' },
+						roles: { $ref: 'UserAsAdmin#/properties/roles' },
 						createdAt: { $ref: 'UserAsAdmin#/properties/createdAt' },
 						editedAt: { $ref: 'UserAsAdmin#/properties/editedAt' },
 						apiKeyEditedAt: {

--- a/packages/backend/src/routes/admin/users/GetUser.ts
+++ b/packages/backend/src/routes/admin/users/GetUser.ts
@@ -22,7 +22,11 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 			uuid: true,
 			username: true,
 			enabled: true,
-			isAdmin: true,
+			roles: {
+				select: {
+					name: true
+				}
+			},
 			createdAt: true,
 			editedAt: true,
 			apiKeyEditedAt: true

--- a/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
+++ b/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
@@ -59,7 +59,11 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 					uuid: true,
 					username: true,
 					enabled: true,
-					isAdmin: true,
+					roles: {
+						select: {
+							name: true
+						}
+					},
 					createdAt: true
 				}
 			}

--- a/packages/backend/src/routes/admin/users/Promote.ts
+++ b/packages/backend/src/routes/admin/users/Promote.ts
@@ -23,10 +23,17 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const user = await prisma.users.findUnique({
 		where: {
 			uuid
+		},
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
 		}
 	});
 
-	if (user?.isAdmin) {
+	if (user?.roles.some(role => role.name === 'admin')) {
 		res.badRequest('User is already an admin');
 		return;
 	}
@@ -36,7 +43,11 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			uuid
 		},
 		data: {
-			isAdmin: true
+			roles: {
+				connect: {
+					name: 'admin'
+				}
+			}
 		}
 	});
 

--- a/packages/backend/src/routes/admin/users/Promote.ts
+++ b/packages/backend/src/routes/admin/users/Promote.ts
@@ -5,7 +5,7 @@ import prisma from '@/structures/database';
 export const options = {
 	url: '/admin/user/:uuid/promote',
 	method: 'post',
-	middlewares: ['auth', 'admin']
+	middlewares: ['auth', 'owner']
 };
 
 export const run = async (req: RequestWithUser, res: FastifyReply) => {

--- a/packages/backend/src/routes/album/links/CreateAlbumLink.ts
+++ b/packages/backend/src/routes/album/links/CreateAlbumLink.ts
@@ -27,7 +27,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	let { identifier } = req.body as { identifier?: string };
 	if (identifier) {
-		if (!req.user.isAdmin) {
+		if (!req.user?.roles.some(role => role.name === 'admin')) {
 			res.unauthorized('Only administrators can create custom links');
 			return;
 		}

--- a/packages/backend/src/routes/auth/Login.ts
+++ b/packages/backend/src/routes/auth/Login.ts
@@ -25,6 +25,13 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 	const user = await prisma.users.findFirst({
 		where: {
 			username
+		},
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
 		}
 	});
 
@@ -55,7 +62,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 			id: user.id,
 			uuid: user.uuid,
 			username: user.username,
-			isAdmin: user.isAdmin,
+			roles: user.roles,
 			apiKey: user.apiKey,
 			passwordEditedAt: user.passwordEditedAt
 		},

--- a/packages/backend/src/routes/auth/Register.ts
+++ b/packages/backend/src/routes/auth/Register.ts
@@ -86,7 +86,12 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 		data: {
 			uuid: userUuid,
 			username,
-			password: hash
+			password: hash,
+			roles: {
+				connect: {
+					name: 'user'
+				}
+			}
 		}
 	});
 

--- a/packages/backend/src/structures/interfaces.ts
+++ b/packages/backend/src/structures/interfaces.ts
@@ -4,7 +4,9 @@ export interface RequestUser {
 	id: number;
 	uuid: string;
 	username: string;
-	isAdmin: boolean;
+	roles: {
+		name: string;
+	}[];
 	apiKey?: string | null | undefined;
 	passwordEditedAt: Date | null;
 }
@@ -23,7 +25,9 @@ export interface User {
 	username: string;
 	password: string;
 	enabled: boolean;
-	isAdmin: boolean;
+	roles: {
+		name: string;
+	}[];
 	apiKey: string;
 	passwordEditedAt: string;
 	apiKeyEditedAt: string;

--- a/packages/backend/src/structures/schemas/FilesAsAdmin.ts
+++ b/packages/backend/src/structures/schemas/FilesAsAdmin.ts
@@ -25,10 +25,19 @@ export default {
 					description: "Whether the user's account is enabled or not.",
 					example: true
 				},
-				isAdmin: {
-					type: 'boolean',
-					description: 'Whether the user is an admin or not.',
-					example: true
+				roles: {
+					type: 'array',
+					description: "The user's roles.",
+					items: {
+						type: 'object',
+						properties: {
+							name: {
+								type: 'string',
+								description: "The role's name.",
+								example: 'admin'
+							}
+						}
+					}
 				},
 				createdAt: {
 					type: 'string',

--- a/packages/backend/src/structures/schemas/RequestUser.ts
+++ b/packages/backend/src/structures/schemas/RequestUser.ts
@@ -13,10 +13,19 @@ export default {
 			description: "The user's username.",
 			example: 'admin'
 		},
-		isAdmin: {
-			type: 'boolean',
-			description: 'Whether or not the user is an administrator.',
-			example: true
+		roles: {
+			type: 'array',
+			description: "The user's roles.",
+			items: {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+						description: "The role's name.",
+						example: 'admin'
+					}
+				}
+			}
 		},
 		apiKey: {
 			type: 'string',

--- a/packages/backend/src/structures/schemas/UserAsAdmin.ts
+++ b/packages/backend/src/structures/schemas/UserAsAdmin.ts
@@ -13,10 +13,19 @@ export default {
 			description: "The user's username.",
 			example: 'admin'
 		},
-		isAdmin: {
-			type: 'boolean',
-			description: 'Whether the user is an admin or not.',
-			example: true
+		roles: {
+			type: 'array',
+			description: "The user's roles.",
+			items: {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+						description: "The role's name.",
+						example: 'admin'
+					}
+				}
+			}
 		},
 		enabled: {
 			type: 'boolean',

--- a/packages/backend/src/utils/StatsGenerator.ts
+++ b/packages/backend/src/utils/StatsGenerator.ts
@@ -185,7 +185,15 @@ export const getUsersInfo = async () => {
 		Disabled: 0
 	};
 
-	const users = await prisma.users.findMany();
+	const users = await prisma.users.findMany({
+		include: {
+			roles: {
+				select: {
+					name: true
+				}
+			}
+		}
+	});
 	stats.Total = users.length;
 
 	for (const user of users) {
@@ -193,7 +201,7 @@ export const getUsersInfo = async () => {
 			stats.Disabled++;
 		}
 
-		if (user.isAdmin) {
+		if (user?.roles.some(role => role.name === 'admin')) {
 			stats.Admins++;
 		}
 	}

--- a/packages/backend/src/utils/UploadHelpers.ts
+++ b/packages/backend/src/utils/UploadHelpers.ts
@@ -35,7 +35,11 @@ export const authUser = async (authorization?: string | null) => {
 			id: true,
 			uuid: true,
 			username: true,
-			isAdmin: true,
+			roles: {
+				select: {
+					name: true
+				}
+			},
 			apiKey: true,
 			passwordEditedAt: true
 		}
@@ -50,7 +54,7 @@ export const authUser = async (authorization?: string | null) => {
 		id: user.id,
 		uuid: user.uuid,
 		username: user.username,
-		isAdmin: user.isAdmin,
+		roles: user.roles,
 		apiKey: user.apiKey
 	} as RequestUser;
 };

--- a/packages/backend/src/utils/Util.ts
+++ b/packages/backend/src/utils/Util.ts
@@ -58,20 +58,33 @@ export const unlistenEmitters = (emitters: any[], eventName: string, listener?: 
 };
 
 export const createAdminUserIfNotExists = async () => {
-	const adminUser = await prisma.users.findFirst({
+	const ownerUser = await prisma.users.findFirst({
 		where: {
-			isAdmin: true
+			roles: {
+				some: {
+					name: 'owner'
+				}
+			}
 		}
 	});
 
-	if (!adminUser) {
+	if (!ownerUser) {
 		const hash = await bcrypt.hash('admin', 10);
 		await prisma.users.create({
 			data: {
 				uuid: uuidv4(),
 				username: 'admin',
 				password: hash,
-				isAdmin: true
+				roles: {
+					connect: [
+						{
+							name: 'owner'
+						},
+						{
+							name: 'admin'
+						}
+					]
+				}
 			}
 		});
 

--- a/packages/frontend/src/components/modals/FileInformationModal.vue
+++ b/packages/frontend/src/components/modals/FileInformationModal.vue
@@ -186,9 +186,9 @@
 											readOnly
 										/>
 										<InputWithOverlappingLabel
-											:value="String(file.user?.isAdmin)"
+											:value="String(file.user?.roles.map(role => role.name).join(', '))"
 											class="mt-4"
-											label="Admin?"
+											label="Roles"
 											readOnly
 										/>
 										<InputWithOverlappingLabel

--- a/packages/frontend/src/components/sidebar/Sidebar.vue
+++ b/packages/frontend/src/components/sidebar/Sidebar.vue
@@ -250,11 +250,7 @@
 			<main class="flex-1">
 				<div id="dashboard-container" class="overflow-auto h-screen">
 					<div
-						v-if="
-							userStore.user?.username === 'admin' &&
-							userStore.user.isAdmin &&
-							!userStore.user.passwordEditedAt
-						"
+						v-if="userStore.user?.username === 'admin' && isAdmin && !userStore.user.passwordEditedAt"
 						class="w-full p-6 flex justify-center items-center text-light-100 bg-red-900"
 					>
 						It seems you are using the admin account but haven't changed the default password yet. Go to the
@@ -305,7 +301,8 @@ const settingsStore = useSettingsStore();
 const modalsStore = useModalStore();
 const updateStore = useUpdateStore();
 
-const isAdmin = computed(() => userStore.user.isAdmin);
+const isAdmin = computed(() => userStore.user.roles?.find(role => role.name === 'admin'));
+const isOwner = computed(() => userStore.user.roles?.find(role => role.name === 'owner'));
 const apiKey = computed(() => userStore.user.apiKey);
 
 const updateCheck = computed(() => updateStore.updateCheck);

--- a/packages/frontend/src/components/table/UsersTable.vue
+++ b/packages/frontend/src/components/table/UsersTable.vue
@@ -68,7 +68,7 @@
 					{{ user.enabled ? 'Enabled' : 'Disabled' }}
 				</td>
 				<td class="hidden px-3 py-4 text-sm text-dark-90 dark:text-light-100 desktop:table-cell">
-					{{ user.isAdmin ? 'Admin' : 'User' }}
+					{{ user.roles.map(role => role.name).join(', ') }}
 				</td>
 				<td class="hidden px-3 py-4 text-sm text-dark-90 dark:text-light-100 desktop:table-cell">
 					{{ formatBytes(user.storageQuota.used) }}
@@ -115,7 +115,7 @@
 							Enable
 						</button>
 						<button
-							v-if="user.isAdmin"
+							v-if="user.roles.some(role => role.name === 'admin')"
 							type="button"
 							class="ml-4 hover:text-blue-400"
 							@click="showManageUserModal(user, 'demote')"

--- a/packages/frontend/src/store/user.ts
+++ b/packages/frontend/src/store/user.ts
@@ -63,7 +63,7 @@ export const useUserStore = defineStore('user', {
 					username: this.user.username,
 					uuid: this.user.uuid,
 					apiKey: this.user.apiKey,
-					isAdmin: this.user.isAdmin,
+					roles: this.user.roles,
 					token: this.user.token
 				})
 			);

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -3,7 +3,9 @@ export interface User {
 	loggedIn: boolean;
 	username: string;
 	uuid: string;
-	isAdmin: boolean;
+	roles: {
+		name: string;
+	}[];
 	apiKey: string;
 	token: string;
 	enabled?: string;
@@ -54,7 +56,9 @@ export interface FileWithAdditionalData extends File {
 		uuid: string;
 		username: string;
 		enabled: boolean;
-		isAdmin: boolean;
+		roles: {
+			name: string;
+		}[];
 		createdAt: number;
 	};
 }

--- a/packages/migration/src/index.ts
+++ b/packages/migration/src/index.ts
@@ -120,7 +120,11 @@ const start = async () => {
 				username: user.username,
 				password: user.password,
 				enabled: user.enabled === 1,
-				isAdmin: user.isAdmin === 1
+				roles: {
+					connect: {
+						name: user.isAdmin === 1 ? 'admin' : 'user'
+					}
+				}
 			}
 		});
 	}


### PR DESCRIPTION
- Instead of `isAdmin` users have roles now
- By default, there is `owner`, `admin` and `user`. The latter is applied to everyone automatically.
- Promoting and demoting admins is only possible for the `owner` roles
- Users with `admin` can't enable/disable other admins or the owner