### PR TITLE
[Feature] Load .env for production, fixed

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
 	},
 	"scripts": {
 		"build": "rimraf \"dist/*/{*.js,!(site/)}\" && tsc && tsc-alias",
-		"start": "yarn migrate && cross-env NODE_ENV=production NODE_PRESERVE_SYMLINKS=1 node -r tsconfig-paths/register dist/main.js",
+		"start": "yarn migrate && cross-env NODE_ENV=production NODE_PRESERVE_SYMLINKS=1 node -r dotenv/config -r tsconfig-paths/register dist/main.js dotenv_config_path=../../.env",
 		"dev": "cross-env NODE_PRESERVE_SYMLINKS=1 ts-node src/main.ts",
 		"dev:reload": "nodemon src/main.ts",
 		"studio": "prisma studio",

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -161,7 +161,8 @@ const start = async () => {
 				'/about',
 				'/privacy',
 				'/tos',
-				'/a/'
+				'/a/',
+				'/s/'
 			];
 
 			const route = routes.some(r => req.url.startsWith(r));

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -26,9 +26,6 @@ export const loadSettings = async (force = false) => {
 
 		// These settings should be set from the environment variables
 		SETTINGS.port = Number.isNaN(Number(process.env.PORT)) ? 8000 : Number(process.env.PORT) ?? 8000;
-		SETTINGS.frontendPort = Number.isNaN(Number(process.env.FRONTEND_PORT))
-			? 8001
-			: Number(process.env.FRONTEND_PORT) ?? 8001;
 		SETTINGS.host = process.env.HOST ?? '0.0.0.0';
 
 		// These are static for now

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -26,6 +26,9 @@ export const loadSettings = async (force = false) => {
 
 		// These settings should be set from the environment variables
 		SETTINGS.port = Number.isNaN(Number(process.env.PORT)) ? 8000 : Number(process.env.PORT) ?? 8000;
+		SETTINGS.frontendPort = Number.isNaN(Number(process.env.FRONTEND_PORT))
+			? 8001
+			: Number(process.env.FRONTEND_PORT) ?? 8001;
 		SETTINGS.host = process.env.HOST ?? '0.0.0.0';
 
 		// These are static for now

--- a/packages/backend/src/utils/Snippet.ts
+++ b/packages/backend/src/utils/Snippet.ts
@@ -40,8 +40,13 @@ export const getUniqueSnippetIdentifier = async (): Promise<string | null> => {
 
 export const constructSnippetPublicLink = (req: FastifyRequest, identifier: string) => {
 	const host = getHost(req);
+	let frontendHost = host;
+	if (process.env.NODE_ENV !== 'production') {
+		frontendHost = host.replace(String(SETTINGS.port), String(SETTINGS.frontendPort));
+	}
+
 	return {
 		raw: `${host}/api/snippet/${identifier}/raw`,
-		link: `${host}/s/${identifier}`
+		link: `${frontendHost}/s/${identifier}`
 	};
 };

--- a/packages/backend/src/utils/Snippet.ts
+++ b/packages/backend/src/utils/Snippet.ts
@@ -42,7 +42,7 @@ export const constructSnippetPublicLink = (req: FastifyRequest, identifier: stri
 	const host = getHost(req);
 	let frontendHost = host;
 	if (process.env.NODE_ENV !== 'production') {
-		frontendHost = host.replace(String(SETTINGS.port), String(SETTINGS.frontendPort));
+		frontendHost = host.replace(String(SETTINGS.port), '8081');
 	}
 
 	return {

--- a/packages/frontend/src/components/highlight/Highlight.vue
+++ b/packages/frontend/src/components/highlight/Highlight.vue
@@ -1,6 +1,8 @@
 <template>
 	<div class="flex">
-		<pre><code class="hljs text-right !pr-0"><div v-for="line in lines" :key="line">{{ line }}</div></code></pre>
+		<pre
+			class="select-none"
+		><code class="hljs text-right !pr-0"><div v-for="line in lines" :key="line">{{ line }}</div></code></pre>
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<pre class="grow"><code class="h-full" :class="className" v-html="code"></code></pre>
 	</div>


### PR DESCRIPTION
- Enable loading .env vars on production start
- Enable `/s/` for snippets during production
- Rewrite the host when running in development mode so that the snippet can be opened from the frontend
- Prevent line numbers to be selected