### PR TITLE
[Fix] Public albums and update notification

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -224,8 +224,7 @@ const start = async () => {
 
 	// Start the server
 	await server.listen({ port: Number(SETTINGS.port), host: SETTINGS.host as string });
-	if (process.env.NODE_ENV === 'production')
-		console.log(`Chibisafe is listening on ${SETTINGS.host}:${SETTINGS.port}`);
+
 	// Jumpstart statistics scheduler
 	await jumpstartStatistics();
 

--- a/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
+++ b/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
@@ -76,16 +76,16 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 		});
 	}
 
-	await prisma.links.update({
-		where: {
-			identifier
-		},
-		data: {
-			views: {
-				increment: 1
-			}
-		}
-	});
+	// await prisma.links.update({
+	// 	where: {
+	// 		identifier
+	// 	},
+	// 	data: {
+	// 		views: {
+	// 			increment: 1
+	// 		}
+	// 	}
+	// });
 
 	return res.send({
 		message: 'Successfully retrieved album',

--- a/packages/frontend/src/components/masonry/Masonry.vue
+++ b/packages/frontend/src/components/masonry/Masonry.vue
@@ -3,8 +3,8 @@
 		<div v-for="(column, i) in fileColumns" :key="i">
 			<div
 				v-for="file in column"
-				:key="file.uuid"
-				v-element-hover="(value: boolean) => onHover(value, file.uuid)"
+				:key="file.uuid ?? file.name"
+				v-element-hover="(value: boolean) => onHover(value, file.uuid ?? file.name)"
 				class="mb-4 m-2 relative"
 			>
 				<FileInformationDialog
@@ -22,6 +22,14 @@
 					<FileWarningIcon class="text-red-500 w-16 h-16" />
 				</div>
 				<template v-else-if="isFileImage(file) || isFileVideo(file)">
+					<a
+						v-if="type === 'publicAlbum'"
+						class="w-full h-full absolute"
+						:href="file?.url"
+						target="_blank"
+						rel="noopener noreferrer"
+						variant="none"
+					/>
 					<img
 						:src="file.thumb"
 						class="cursor-pointer w-full min-w-[160px]"
@@ -29,7 +37,7 @@
 					/>
 
 					<video
-						v-if="isFileVideo(file) && isHovered[file.uuid]"
+						v-if="isFileVideo(file) && isHovered[file.uuid ?? file.name]"
 						class="preview absolute top-0 left-0 w-full h-full pointer-events-none min-w-[160px]"
 						autoplay
 						loop
@@ -48,8 +56,11 @@
 					<FileAudioIcon v-if="isFileAudio(file)" class="text-light-100 w-16 h-16" />
 					<FileTextIcon v-else-if="isFilePDF(file)" class="text-light-100 w-16 h-16" />
 					<FileIcon v-else class="text-light-100 w-16 h-16" />
-					<span class="text-light-100 mt-4 text-lg text-center break-all w-[160px]">{{
+					<span v-if="file.original" class="text-light-100 mt-4 text-lg text-center break-all w-[160px]">{{
 						file.original.length > 60 ? `${file.original.substring(0, 40)}...` : file.original
+					}}</span>
+					<span v-else class="text-light-100 mt-4 text-lg text-center break-all w-[160px]">{{
+						file.name.length > 60 ? `${file.name.substring(0, 40)}...` : file.name
 					}}</span>
 				</div>
 			</div>

--- a/packages/frontend/src/components/sidebar/Sidebar.vue
+++ b/packages/frontend/src/components/sidebar/Sidebar.vue
@@ -79,7 +79,7 @@
 								v-if="isAdmin && updateCheck?.updateAvailable"
 								class="mt-1 space-y-1 p-2 flex flex-col justify-center items-center text-light-100 bg-dark-85 text-xs"
 							>
-								<div>
+								<div class="text-center">
 									New version available
 									<a
 										:href="updateCheck.latestVersionUrl"
@@ -95,6 +95,9 @@
 									</span>
 								</ReleaseNotesDialog>
 							</div>
+							<span class="text-light-100 justify-center flex !mt-4 text-sm pointer-events-none"
+								>chibisafe v{{ VERSION }}</span
+							>
 						</div>
 					</div>
 				</div>
@@ -134,6 +137,9 @@ const settingsStore = useSettingsStore();
 const updateStore = useUpdateStore();
 
 const isOpen = ref(false);
+// @ts-ignore
+// eslint-disable-next-line no-undef
+const VERSION = PACKAGE_VERSION;
 
 const isAdmin = computed(() => userStore.user.roles?.find(role => role.name === 'admin'));
 const apiKey = computed(() => userStore.user.apiKey);
@@ -189,7 +195,6 @@ const links = [
 ];
 
 const logout = async (event: MouseEvent) => {
-	console.log('adasd');
 	event.preventDefault();
 	await router.push('/');
 	userStore.logout();

--- a/packages/frontend/src/pages/a/[identifier].vue
+++ b/packages/frontend/src/pages/a/[identifier].vue
@@ -1,19 +1,22 @@
 <template>
-	<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 w-full">
-		<h1 class="text-2xl mt-8 font-semibold text-light-100">{{ data?.name }} ({{ data?.count }} files)</h1>
-		<div v-if="data?.isNsfw && !enableNsfw" class="text-light-100 w-full flex flex-col mt-24 text-center">
-			<h2>This album is NSFW, to view the contents click on the button below</h2>
-			<Button variant="primary" class="mt-8" @click="enableNsfw = true">Show content</Button>
+	<ScrollArea class="h-screen">
+		<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 w-full">
+			<h1 class="text-2xl mt-8 font-semibold text-light-100">{{ data?.name }} ({{ data?.count }} files)</h1>
+			<div v-if="data?.isNsfw && !enableNsfw" class="text-light-100 w-full flex flex-col mt-24 text-center">
+				<h2>This album is NSFW, to view the contents click on the button below</h2>
+				<Button variant="primary" class="mt-8" @click="enableNsfw = true">Show content</Button>
+			</div>
+			<template v-else>
+				<FilesWrapper type="publicAlbum" :identifier="identifier" />
+			</template>
 		</div>
-		<template v-else>
-			<FilesWrapper type="publicAlbum" :identifier="identifier" />
-		</template>
-	</div>
+	</ScrollArea>
 </template>
 
 <script setup lang="ts">
 import { useQuery } from '@tanstack/vue-query';
 import { computed, ref } from 'vue';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { getFilesFromPublicAlbum } from '@/use/api';
 import Button from '~/components/buttons/Button.vue';
 import FilesWrapper from '~/components/wrappers/FilesWrapper.vue';


### PR DESCRIPTION
- Public albums were not being displayed correctly
- Public albums were not scrollable
- Public album files were not clickable
- Public albums endpoint would hang with 500 API error when updating the amount of visits a link has, which has now been commented out for the time being
- New version notification wasn't properly aligned
- Dashboard now shows chibisafe version at the bottom