### PR TITLE
fix: migrate-v4-from-v5 script

### DIFF
--- a/packages/migration/src/index.ts
+++ b/packages/migration/src/index.ts
@@ -80,6 +80,7 @@ const start = async () => {
 		validate(value) {
 			if (value.length === 0) return `Value is required!`;
 			if (!value.endsWith('.sqlite')) return `Value must be a .sqlite file!`;
+			return '';
 		}
 	});
 

--- a/packages/migration/tsconfig.json
+++ b/packages/migration/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"target": "es6",
+		"module": "commonjs",
+		"esModuleInterop": true,
+	}
+}


### PR DESCRIPTION
this makes the script properly executable, and properly migrates the v4 database to the v5 schema.