### PR TITLE
[Fix] Properly delete quarantined items

### DIFF
--- a/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
+++ b/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
@@ -54,6 +54,12 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 			size: true,
 			type: true,
 			uuid: true,
+			quarantine: true,
+			quarantineFile: {
+				select: {
+					name: true
+				}
+			},
 			user: {
 				select: {
 					uuid: true,

--- a/packages/frontend/src/components/dialogs/FileInformationDialog.vue
+++ b/packages/frontend/src/components/dialogs/FileInformationDialog.vue
@@ -299,6 +299,7 @@ const onOpen = async (isOpen: boolean) => {
 };
 
 const getFileAlbums = async () => {
+	if (props.type === 'admin') return;
 	const file = await getFile(props.file.uuid);
 	fileAlbums.value = file.albums;
 };


### PR DESCRIPTION
- Fixed an issue where an admin wouldn't be able to delete a quarantined item (fixes #508)
- Fixed an issue where deleting a quarantined item wouldn't get rid of the file, only the database entry