### PR TITLE
Making the Frontpage use the SI Standard for file sizes, make Login error more ambiguous and download button

### DIFF
--- a/packages/backend/src/routes/auth/Login.ts
+++ b/packages/backend/src/routes/auth/Login.ts
@@ -36,13 +36,13 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 	});
 
 	if (!user) {
-		res.unauthorized("User doesn't exist");
+		res.unauthorized('Wrong Username or Password');
 		return;
 	}
 
 	const comparePassword = await bcrypt.compare(password, user.password);
 	if (!comparePassword) {
-		res.unauthorized('Wrong password');
+		res.unauthorized('Wrong Username or Password');
 		return;
 	}
 

--- a/packages/frontend/src/components/dialogs/FileInformationDialog.vue
+++ b/packages/frontend/src/components/dialogs/FileInformationDialog.vue
@@ -95,6 +95,14 @@
 								>
 									<Button>Regenerate thumbnail</Button></ConfirmationDialog
 								>
+								<Button
+									as="a" 
+									:href="file.url" 
+									:download="file.original"
+									class="flex-1"
+								>
+									Download
+								</Button>
 								<ConfirmationDialog
 									v-if="isAdmin && !file.quarantine"
 									title="Quarantine file"

--- a/packages/frontend/src/use/file.ts
+++ b/packages/frontend/src/use/file.ts
@@ -9,7 +9,7 @@ export const formatBytes = (bytes: number, decimals = 2) => {
 		decimals = 1;
 	}
 
-	const k = 1024;
+	const k = 1000;
 	const dm = decimals < 0 ? 0 : decimals;
 	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
 


### PR DESCRIPTION
I've undertaken two slight changes which I myself have now on my instance. First, I've changed the "file.ts" file to now count 1k bytes as one kilo and not 1024. This issue I've detailed in #521. 

The second edit is something that I've recently noticed and found worth changing. It is to remove the "user doesn't exist" and "wrong password" error messages and replace them both with a more generic error. This is to prevent people from bruteforcing usernames.

Edit: I've now also added a download button in the file info dialog which downloads a file as the original name. This makes it so that whoever owns the file can download it under it's original name from the UI. 