### PR TITLE
[Fix] Snippet download URL

### DIFF
--- a/packages/backend/src/utils/Snippet.ts
+++ b/packages/backend/src/utils/Snippet.ts
@@ -37,7 +37,7 @@ export const getUniqueSnippetIdentifier = async (): Promise<string | null> => {
 };
 
 export const constructSnippetPublicLink = (req: FastifyRequest, identifier: string) => {
-	const host = getHost(req);
+	const host = SETTINGS.serveUploadsFrom ? SETTINGS.serveUploadsFrom : getHost(req);
 	let frontendHost = host;
 	if (process.env.NODE_ENV !== 'production') {
 		frontendHost = host.replace(String(SETTINGS.port), '8001');

--- a/packages/frontend/src/components/dialogs/FileInformationDialog.vue
+++ b/packages/frontend/src/components/dialogs/FileInformationDialog.vue
@@ -95,12 +95,7 @@
 								>
 									<Button>Regenerate thumbnail</Button></ConfirmationDialog
 								>
-								<Button
-									as="a" 
-									:href="file.url" 
-									:download="file.original"
-									class="flex-1"
-								>
+								<Button as="a" :href="file.url" :download="file.original" class="flex-1">
 									Download
 								</Button>
 								<ConfirmationDialog

--- a/packages/frontend/src/components/table/FilesTable.vue
+++ b/packages/frontend/src/components/table/FilesTable.vue
@@ -41,7 +41,14 @@
 					}}</a>
 				</TableCell>
 				<TableCell>
-					{{ file.original }}
+					<a
+						:href="file.url"
+						:download="file.original"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="hover:text-blue-400"
+						>{{ file.original }}</a
+					>
 				</TableCell>
 				<TableCell>
 					{{ formatBytes(Number(file.size)) }}


### PR DESCRIPTION
- Fixed an issue were using a custom value to serve files from didn't apply to snippets
- Added a download link to download files with their original filenames on the table view