### PR TITLE
[Fix] Remove sharp

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -59,7 +59,6 @@
 		"pino-pretty": "^10.3.1",
 		"proxy-addr": "^2.0.7",
 		"randomstring": "^1.3.0",
-		"sharp": "^0.33.1",
 		"systeminformation": "^5.21.22",
 		"tsc-alias": "^1.8.8",
 		"tsconfig-paths": "^4.2.0",

--- a/packages/backend/src/utils/Thumbnails.ts
+++ b/packages/backend/src/utils/Thumbnails.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { URL, fileURLToPath } from 'node:url';
 import ffmpeg from 'fluent-ffmpeg';
 import jetpack from 'fs-jetpack';
-import sharp from 'sharp';
 import { log } from './Logger.js';
 import previewUtil from './videoPreview/FragmentPreview.js';
 
@@ -16,9 +15,19 @@ const videoPreviewPath = fileURLToPath(new URL('../../../../uploads/thumbs/previ
 const generateThumbnailForImage = async (filename: string, output: string) => {
 	const filePath = fileURLToPath(new URL(`../../../../uploads/${filename}`, import.meta.url));
 
-	const file = await jetpack.readAsync(filePath, 'buffer');
-	await sharp(file).resize(64, 64).toFormat('webp').toFile(path.join(squareThumbPath, output));
-	await sharp(file).resize(225, null).toFormat('webp').toFile(path.join(thumbPath, output));
+	ffmpeg(filePath)
+		.size('64x64')
+		.format('webp')
+		.output(path.join(squareThumbPath, output))
+		.on('error', error => log.error(error.message))
+		.run();
+
+	ffmpeg(filePath)
+		.size('255x?')
+		.format('webp')
+		.output(path.join(thumbPath, output))
+		.on('error', error => log.error(error.message))
+		.run();
 };
 
 const generateThumbnailForVideo = async (filename: string, output: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,7 +302,6 @@ __metadata:
     proxy-addr: ^2.0.7
     randomstring: ^1.3.0
     rimraf: ^5.0.5
-    sharp: ^0.33.1
     systeminformation: ^5.21.22
     tsc-alias: ^1.8.8
     tsconfig-paths: ^4.2.0
@@ -9635,7 +9634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:*, sharp@npm:^0.33.1":
+"sharp@npm:*":
   version: 0.33.1
   resolution: "sharp@npm:0.33.1"
   dependencies:


### PR DESCRIPTION
A user on Discord was having an issue with images being black and white, and after further investigation this is happening to other people as well:

https://github.com/lovell/sharp/issues/3893
https://github.com/lovell/sharp/issues/3894
https://github.com/lovell/sharp/issues/3902

Since we're already using `ffmpeg` and `fluent-ffmpeg`, I decided to remove sharp and move that logic over to ffmpeg directly which seems to solve the issue. 