### PR TITLE
[Feature] Add album descriptions

### DIFF
--- a/packages/backend/src/prisma/migrations/20240115115628_add_description_to_albums_and_snippets/migration.sql
+++ b/packages/backend/src/prisma/migrations/20240115115628_add_description_to_albums_and_snippets/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "albums" ADD COLUMN "description" TEXT;
+
+-- AlterTable
+ALTER TABLE "snippets" ADD COLUMN "description" TEXT;

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -62,6 +62,7 @@ model snippets {
 	userId Int?
 	identifier String @unique
 	name String
+	description String?
 	content String
 	language String
 	parentUuid String?
@@ -74,6 +75,7 @@ model albums {
 	uuid String @unique
 	userId Int
 	name String
+	description String?
 	zippedAt DateTime?
 	createdAt DateTime @default(now())
 	editedAt DateTime?

--- a/packages/backend/src/routes/album/GetAlbum.schema.ts
+++ b/packages/backend/src/routes/album/GetAlbum.schema.ts
@@ -25,6 +25,11 @@ export default {
 			properties: {
 				message: { $ref: 'ResponseMessage' },
 				name: { type: 'string', description: 'The name of the album.', example: 'Cats' },
+				description: {
+					type: 'string',
+					description: 'The description of the album.',
+					example: 'But dogs really'
+				},
 				isNsfw: { type: 'boolean', description: 'Whether or not the album is nsfw.', example: false },
 				count: { type: 'number', description: 'The number of files in the album.', example: 1 },
 				files: {

--- a/packages/backend/src/routes/album/GetAlbum.ts
+++ b/packages/backend/src/routes/album/GetAlbum.ts
@@ -27,6 +27,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		},
 		select: {
 			name: true,
+			description: true,
 			nsfw: true,
 			files: {
 				select: {
@@ -66,6 +67,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	return res.send({
 		message: 'Successfully retrieved album',
 		name: album.name,
+		description: album.description,
 		files,
 		isNsfw: album.nsfw,
 		count: album._count.files

--- a/packages/backend/src/routes/album/GetAlbumWithIdentifier.schema.ts
+++ b/packages/backend/src/routes/album/GetAlbumWithIdentifier.schema.ts
@@ -28,6 +28,11 @@ export default {
 					type: 'object',
 					properties: {
 						name: { type: 'string', description: 'The name of the album.', example: 'My Album' },
+						description: {
+							type: 'string',
+							description: 'The description of the album.',
+							example: 'My great album about dogs.'
+						},
 						isNsfw: { type: 'boolean', description: 'Whether or not the album is NSFW.', example: false },
 						count: { type: 'number', description: 'The amount of files in the album.', example: 5 },
 						files: {

--- a/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
+++ b/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
@@ -46,6 +46,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 		},
 		select: {
 			name: true,
+			description: true,
 			nsfw: true,
 			files: {
 				select: {
@@ -91,6 +92,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 		message: 'Successfully retrieved album',
 		album: {
 			name: album.name,
+			description: album.description,
 			files,
 			isNsfw: album.nsfw,
 			count: album._count.files

--- a/packages/backend/src/routes/album/GetAlbums.schema.ts
+++ b/packages/backend/src/routes/album/GetAlbums.schema.ts
@@ -18,6 +18,11 @@ export default {
 								example: '1453821d-aaf9-435c-8a51-e3f16f7d2ee5'
 							},
 							name: { type: 'string', description: 'The name of the album.', example: 'My Album' },
+							description: {
+								type: 'string',
+								description: 'The description of the album.',
+								example: 'My album description.'
+							},
 							nsfw: { type: 'boolean', description: 'Whether or not the album is NSFW.', example: false },
 							zippedAt: {
 								type: 'string',

--- a/packages/backend/src/routes/album/GetAlbums.ts
+++ b/packages/backend/src/routes/album/GetAlbums.ts
@@ -17,6 +17,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		select: {
 			uuid: true,
 			name: true,
+			description: true,
 			nsfw: true,
 			zippedAt: true,
 			createdAt: true,

--- a/packages/backend/src/routes/album/UpdateAlbum.schema.ts
+++ b/packages/backend/src/routes/album/UpdateAlbum.schema.ts
@@ -19,6 +19,10 @@ export default {
 				type: 'string',
 				description: 'The name of the album.'
 			},
+			description: {
+				type: 'string',
+				description: 'The description of the album.'
+			},
 			nsfw: {
 				type: 'boolean',
 				description: 'Whether the album is nsfw or not.'
@@ -26,7 +30,7 @@ export default {
 		},
 		minProperties: 1,
 		additionalProperties: false,
-		anyOf: [{ required: ['name'] }, { required: ['nsfw'] }]
+		anyOf: [{ required: ['name'] }, { required: ['nsfw'] }, { required: ['description'] }]
 	},
 	response: {
 		200: {

--- a/packages/backend/src/routes/album/UpdateAlbum.ts
+++ b/packages/backend/src/routes/album/UpdateAlbum.ts
@@ -11,8 +11,8 @@ export const options = {
 export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const { uuid } = req.params as { uuid: string };
 
-	const { name, nsfw } = req.body as { name?: string; nsfw?: boolean };
-	if (!name && nsfw === undefined) {
+	const { name, nsfw, description } = req.body as { description?: string; name?: string; nsfw?: boolean };
+	if (!name && nsfw === undefined && !description) {
 		void res.badRequest('No data supplied');
 		return;
 	}
@@ -32,7 +32,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const updateObj = {
 		name: name ?? album.name,
-		nsfw: nsfw === true ? true : nsfw === false ? false : album.nsfw
+		nsfw: nsfw === true ? true : nsfw === false ? false : album.nsfw,
+		description: description ?? album.description
 	};
 
 	await prisma.albums.update({

--- a/packages/backend/src/routes/snippet/GetSnippet.schema.ts
+++ b/packages/backend/src/routes/snippet/GetSnippet.schema.ts
@@ -25,6 +25,11 @@ export default {
 							description: 'The name of the snippet.',
 							example: 'HelloWorld.ts'
 						},
+						description: {
+							type: 'string',
+							description: 'The description of the snippet.',
+							example: 'A simple hello world snippet.'
+						},
 						content: {
 							type: 'string',
 							description: 'The content of the snippet.',

--- a/packages/backend/src/routes/snippet/GetSnippet.ts
+++ b/packages/backend/src/routes/snippet/GetSnippet.ts
@@ -21,6 +21,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			content: true,
 			language: true,
 			name: true,
+			description: true,
 			parentUuid: true,
 			uuid: true,
 			identifier: true,

--- a/packages/frontend/src/components/dialogs/AlbumSettingsDialog.vue
+++ b/packages/frontend/src/components/dialogs/AlbumSettingsDialog.vue
@@ -16,6 +16,16 @@
 			</div>
 
 			<DialogHeader class="mt-4">
+				<DialogTitle>Album description</DialogTitle>
+				<DialogDescription>
+					{{ album.description || 'No description set' }}
+				</DialogDescription>
+				<InputDialog message="Add an album description" title="Description" :callback="setDescription">
+					<Button class="shrink-0">Set description</Button>
+				</InputDialog>
+			</DialogHeader>
+
+			<DialogHeader class="mt-4">
 				<DialogTitle>Album links</DialogTitle>
 				<DialogDescription>
 					A list of all the links created for this album. Each link is unique and will remain private unless
@@ -54,6 +64,7 @@
 import { ref, computed } from 'vue';
 import { toast } from 'vue-sonner';
 import ConfirmationDialog from '@/components/dialogs/ConfirmationDialog.vue';
+import InputDialog from '@/components/dialogs/InputDialog.vue';
 import InputWithLabel from '@/components/input/InputWithLabel.vue';
 import AlbumLinksTable from '@/components/table/AlbumLinksTable.vue';
 import { Button } from '@/components/ui/button';
@@ -107,6 +118,14 @@ const createLink = async () => {
 	const newLink = await createAlbumLink(props.album.uuid);
 	albumsStore.currentAlbumLinks.push(newLink.data);
 	toast.success('New link created');
+};
+
+const setDescription = async (description: string) => {
+	await updateAlbum(props.album.uuid, {
+		name: 'description',
+		value: description
+	});
+	toast.success('Changed album description');
 };
 
 const setNewAlbumName = async () => {

--- a/packages/frontend/src/components/dialogs/FileInformationDialog.vue
+++ b/packages/frontend/src/components/dialogs/FileInformationDialog.vue
@@ -96,12 +96,7 @@
 									>
 										<Button>Regenerate thumbnail</Button></ConfirmationDialog
 									>
-									<Button
-										as="a" 
-										:href="file.url" 
-										:download="file.original"
-										class="flex-1"
-									>
+									<Button as="a" :href="file.url" :download="file.original" class="flex-1">
 										Download
 									</Button>
 									<ConfirmationDialog
@@ -123,22 +118,12 @@
 									>
 								</div>
 							</div>
-							
+
 							<div class="mb-8 max-w-[calc(100vw-12rem)]">
 								<h2 class="text-light-100">File info</h2>
 
-								<InputWithOverlappingLabel 
-									:value="file.uuid"
-									class="mt-4"
-									label="UUID" 
-									readOnly 
-								/>
-								<InputWithOverlappingLabel 
-									:value="file.name"
-									class="mt-4"
-									label="Name" 
-									readOnly
-								/>
+								<InputWithOverlappingLabel :value="file.uuid" class="mt-4" label="UUID" readOnly />
+								<InputWithOverlappingLabel :value="file.name" class="mt-4" label="Name" readOnly />
 								<InputWithOverlappingLabel
 									:value="file.original"
 									class="mt-4"
@@ -167,12 +152,7 @@
 									label="Size"
 									readOnly
 								/>
-								<InputWithOverlappingLabel
-									:value="file.hash"
-									class="mt-4"
-									label="Hash"
-									readOnly
-								/>
+								<InputWithOverlappingLabel :value="file.hash" class="mt-4" label="Hash" readOnly />
 								<InputWithOverlappingLabel
 									:value="dayjs(file.createdAt).format('MMMM D, YYYY h:mm A')"
 									class="mt-4"
@@ -182,7 +162,10 @@
 							</div>
 
 							<!-- Albums section -->
-							<div v-if="type === 'album' || type === 'uploads' || type === 'tag'" class="mb-8 max-w-[calc(100vw-12rem)]">
+							<div
+								v-if="type === 'album' || type === 'uploads' || type === 'tag'"
+								class="mb-8 max-w-[calc(100vw-12rem)]"
+							>
 								<h2 class="text-light-100">Albums</h2>
 								<Combobox
 									:data="albumsForCombobox"
@@ -208,7 +191,10 @@
 							</div>
 
 							<!-- Tags -->
-							<div v-if="type === 'album' || type === 'uploads' || type === 'tag'" class="mb-8 max-w-[calc(100vw-12rem)]">
+							<div
+								v-if="type === 'album' || type === 'uploads' || type === 'tag'"
+								class="mb-8 max-w-[calc(100vw-12rem)]"
+							>
 								<h2 class="text-light-100">Tags</h2>
 								<TagBox
 									:tags="tags"
@@ -229,7 +215,7 @@
 									type="link"
 									:href="`/dashboard/admin/user/${file.user?.uuid}`"
 								/>
-								<InputWithOverlappingLabel 
+								<InputWithOverlappingLabel
 									:value="file.user?.uuid"
 									class="mt-4"
 									label="UUID"

--- a/packages/frontend/src/pages/a/[identifier].vue
+++ b/packages/frontend/src/pages/a/[identifier].vue
@@ -5,6 +5,10 @@
 				{{ albumInfo?.name }} ({{ albumInfo?.count }} files)
 			</h1>
 
+			<h2 v-if="albumInfo?.description" class="text-xl mt-4 text-light-100">
+				{{ albumInfo?.description }}
+			</h2>
+
 			<div v-if="albumInfo?.isNsfw && !enableNsfw" class="text-light-100 w-full flex flex-col mt-24 text-center">
 				<h2>This album is NSFW, to view the contents click on the button below</h2>
 				<Button variant="primary" class="mt-8" @click="enableNsfw = true">Show content</Button>

--- a/packages/frontend/src/store/albums.ts
+++ b/packages/frontend/src/store/albums.ts
@@ -45,6 +45,7 @@ export const useAlbumsStore = defineStore('albums', {
 			this.album = {
 				uuid,
 				name: response.name,
+				description: response.description,
 				files: response.files,
 				isNsfw: response.isNsfw,
 				count: response.count

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -72,6 +72,7 @@ export interface Album {
 	count?: number;
 	cover?: string;
 	createdAt: string;
+	description: string;
 	editedAt: string;
 	files?: FileWithAdditionalData[];
 	name: string;
@@ -82,6 +83,7 @@ export interface Album {
 
 export interface AlbumForMasonry {
 	count: number;
+	description: string;
 	files: FileWithAdditionalData[];
 	isNsfw: boolean;
 	name: string;
@@ -136,6 +138,7 @@ export interface UpdateCheck {
 export interface Snippet {
 	content: string;
 	createdAt: string;
+	description: string;
 	language: string;
 	link: string;
 	name: string;


### PR DESCRIPTION
This PRs adds the ability to give descriptions to album.
1. Go to the dashboard
2. Click on albums
3. Click on album settings icon
4. Set description

Now whenever you share a link to the album the description will appear beneath the name of the album.

Closes #517 


