### PR TITLE
[Feature] Add S3 storage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "chibisafe",
-	"version": "5.4.0",
+	"version": "5.5.0",
 	"description": "Blazing fast file uploader and bunker written in node! 🚀",
 	"private": true,
 	"scripts": {
@@ -24,9 +24,8 @@
 		"url": "https://github.com/Pitu"
 	},
 	"license": "MIT",
-	"volta": {
-		"node": "18.9.0",
-		"yarn": "3.6.0"
+	"engines": {
+		"node": ">=18.9.0"
 	},
 	"packageManager": "yarn@3.6.0",
 	"workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,10 +28,9 @@
 	"bugs": {
 		"url": "https://github.com/WeebDev/chibisafe/issues"
 	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
 	"dependencies": {
+		"@aws-sdk/client-s3": "^3.504.0",
+		"@aws-sdk/s3-request-presigner": "^3.504.0",
 		"@chibisafe/uploader-module": "1.0.10",
 		"@fastify/cors": "^8.5.0",
 		"@fastify/helmet": "^11.1.1",
@@ -101,7 +100,7 @@
 		"file uploader",
 		"images"
 	],
-	"volta": {
-		"node": "18.9.0"
+	"engines": {
+		"node": ">=18.9.0"
 	}
 }

--- a/packages/backend/src/prisma/migrations/20240203184527_add_s3_storage_support/migration.sql
+++ b/packages/backend/src/prisma/migrations/20240203184527_add_s3_storage_support/migration.sql
@@ -1,0 +1,62 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_settings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "rateLimitWindow" INTEGER NOT NULL,
+    "rateLimitMax" INTEGER NOT NULL,
+    "secret" TEXT NOT NULL,
+    "serviceName" TEXT NOT NULL,
+    "chunkSize" TEXT NOT NULL,
+    "chunkedUploadsTimeout" INTEGER NOT NULL,
+    "maxSize" TEXT NOT NULL,
+    "generateZips" BOOLEAN NOT NULL,
+    "generatedFilenameLength" INTEGER NOT NULL,
+    "generatedAlbumLength" INTEGER NOT NULL,
+    "blockedExtensions" TEXT NOT NULL,
+    "blockNoExtension" BOOLEAN NOT NULL,
+    "publicMode" BOOLEAN NOT NULL,
+    "userAccounts" BOOLEAN NOT NULL,
+    "disableStatisticsCron" BOOLEAN NOT NULL,
+    "disableUpdateCheck" BOOLEAN NOT NULL DEFAULT false,
+    "backgroundImageURL" TEXT NOT NULL,
+    "logoURL" TEXT NOT NULL,
+    "metaDescription" TEXT NOT NULL,
+    "metaKeywords" TEXT NOT NULL,
+    "metaTwitterHandle" TEXT NOT NULL,
+    "metaDomain" TEXT NOT NULL DEFAULT '',
+    "serveUploadsFrom" TEXT NOT NULL DEFAULT '',
+    "enableMixedCaseFilenames" BOOLEAN NOT NULL DEFAULT true,
+    "usersStorageQuota" TEXT NOT NULL DEFAULT '0',
+    "useNetworkStorage" BOOLEAN NOT NULL DEFAULT false,
+    "S3Region" TEXT NOT NULL DEFAULT '',
+    "S3Bucket" TEXT NOT NULL DEFAULT '',
+    "S3AccessKey" TEXT NOT NULL DEFAULT '',
+    "S3SecretKey" TEXT NOT NULL DEFAULT '',
+    "S3Endpoint" TEXT NOT NULL DEFAULT '',
+    "S3PublicUrl" TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO "new_settings" ("backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "disableUpdateCheck", "enableMixedCaseFilenames", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "id", "logoURL", "maxSize", "metaDescription", "metaDomain", "metaKeywords", "metaTwitterHandle", "publicMode", "rateLimitMax", "rateLimitWindow", "secret", "serveUploadsFrom", "serviceName", "userAccounts", "usersStorageQuota") SELECT "backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "disableUpdateCheck", "enableMixedCaseFilenames", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "id", "logoURL", "maxSize", "metaDescription", "metaDomain", "metaKeywords", "metaTwitterHandle", "publicMode", "rateLimitMax", "rateLimitWindow", "secret", "serveUploadsFrom", "serviceName", "userAccounts", "usersStorageQuota" FROM "settings";
+DROP TABLE "settings";
+ALTER TABLE "new_settings" RENAME TO "settings";
+CREATE TABLE "new_files" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "uuid" TEXT NOT NULL,
+    "userId" INTEGER,
+    "name" TEXT NOT NULL,
+    "original" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "size" TEXT NOT NULL,
+    "hash" TEXT NOT NULL,
+    "ip" TEXT NOT NULL,
+    "isS3" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "editedAt" DATETIME,
+    "quarantine" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "files_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_files" ("createdAt", "editedAt", "hash", "id", "ip", "name", "original", "quarantine", "size", "type", "userId", "uuid") SELECT "createdAt", "editedAt", "hash", "id", "ip", "name", "original", "quarantine", "size", "type", "userId", "uuid" FROM "files";
+DROP TABLE "files";
+ALTER TABLE "new_files" RENAME TO "files";
+CREATE UNIQUE INDEX "files_uuid_key" ON "files"("uuid");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -40,6 +40,7 @@ model files {
 	size String
 	hash String
 	ip String
+	isS3 Boolean @default(false)
 	createdAt DateTime @default(now())
 	editedAt DateTime?
 	user users? @relation(fields: [userId], references: [id])
@@ -130,6 +131,13 @@ model settings {
 	serveUploadsFrom String @default("")
 	enableMixedCaseFilenames Boolean @default(true)
 	usersStorageQuota String @default("0")
+	useNetworkStorage Boolean @default(false)
+	S3Region String @default("")
+	S3Bucket String @default("")
+	S3AccessKey String @default("")
+	S3SecretKey String @default("")
+	S3Endpoint String @default("")
+	S3PublicUrl String @default("")
 }
 
 model statistics {

--- a/packages/backend/src/routes/GetSettings.schema.ts
+++ b/packages/backend/src/routes/GetSettings.schema.ts
@@ -48,6 +48,11 @@ export default {
 						type: 'string',
 						example: 'exe'
 					}
+				},
+				useNetworkStorage: {
+					type: 'boolean',
+					description: 'Whether or not network storage is enabled.',
+					example: false
 				}
 			}
 		}

--- a/packages/backend/src/routes/GetSettings.ts
+++ b/packages/backend/src/routes/GetSettings.ts
@@ -16,6 +16,7 @@ export const run = (_: RequestWithUser, res: FastifyReply) => {
 		backgroundImageURL: SETTINGS.backgroundImageURL,
 		publicMode: SETTINGS.publicMode,
 		userAccounts: SETTINGS.userAccounts,
-		blockedExtensions: SETTINGS.blockedExtensions
+		blockedExtensions: SETTINGS.blockedExtensions,
+		useNetworkStorage: SETTINGS.useNetworkStorage
 	});
 };

--- a/packages/backend/src/routes/admin/files/DeleteFile.ts
+++ b/packages/backend/src/routes/admin/files/DeleteFile.ts
@@ -22,7 +22,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		select: {
 			name: true,
 			quarantine: true,
-			quarantineFile: true
+			quarantineFile: true,
+			isS3: true
 		}
 	});
 
@@ -55,7 +56,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	});
 
 	// Remove the file from disk
-	await deleteFile(file.name);
+	await deleteFile({ filename: file.name, isS3: file.isS3 });
 
 	return res.send({
 		message: 'Successfully deleted the file'

--- a/packages/backend/src/routes/admin/files/GetFile.ts
+++ b/packages/backend/src/routes/admin/files/GetFile.ts
@@ -63,7 +63,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const extendedFile = {
 		...file,
-		...constructFilePublicLink(req, file.name)
+		...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3 })
 	};
 
 	return res.send({

--- a/packages/backend/src/routes/admin/files/GetFiles.ts
+++ b/packages/backend/src/routes/admin/files/GetFiles.ts
@@ -44,7 +44,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 				select: {
 					name: true
 				}
-			}
+			},
+			isS3: true
 		},
 		orderBy: {
 			id: 'desc'
@@ -89,7 +90,12 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink(req, quarantine ? file.quarantineFile.name : file.name, quarantine)
+			...constructFilePublicLink({
+				req,
+				fileName: quarantine ? file.quarantineFile.name : file.name,
+				quarantine,
+				isS3: file.isS3
+			})
 		});
 	}
 

--- a/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
+++ b/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
@@ -34,7 +34,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink(req, file.name)
+			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3 })
 		});
 	}
 

--- a/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
+++ b/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
@@ -60,6 +60,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 					name: true
 				}
 			},
+			isS3: true,
 			user: {
 				select: {
 					uuid: true,
@@ -83,7 +84,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink(req, file.name)
+			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3 })
 		});
 	}
 

--- a/packages/backend/src/routes/album/GetAlbum.ts
+++ b/packages/backend/src/routes/album/GetAlbum.ts
@@ -38,7 +38,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 					original: true,
 					size: true,
 					type: true,
-					uuid: true
+					uuid: true,
+					isS3: true
 				},
 				orderBy: {
 					id: 'desc'
@@ -60,7 +61,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		const modifiedFile = file as unknown as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLink(req, modifiedFile.name)
+			...constructFilePublicLink({ req, fileName: modifiedFile.name, isS3: file.isS3 })
 		});
 	}
 

--- a/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
+++ b/packages/backend/src/routes/album/GetAlbumWithIdentifier.ts
@@ -51,7 +51,8 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 			files: {
 				select: {
 					name: true,
-					type: true
+					type: true,
+					isS3: true
 				},
 				orderBy: {
 					id: 'desc'
@@ -73,7 +74,7 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 		const modifiedFile = file as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLink(req, modifiedFile.name)
+			...constructFilePublicLink({ req, fileName: modifiedFile.name, isS3: file.isS3 })
 		});
 	}
 

--- a/packages/backend/src/routes/album/GetAlbums.ts
+++ b/packages/backend/src/routes/album/GetAlbums.ts
@@ -57,7 +57,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		delete newObject._count;
 
 		newObject.cover = album.files[0]
-			? constructFilePublicLink(req, album.files[0].name as unknown as any).thumbSquare
+			? constructFilePublicLink({ req, fileName: album.files[0].name as unknown as any }).thumbSquare
 			: '';
 		fetchedAlbums.push(newObject);
 	}

--- a/packages/backend/src/routes/files/DeleteFile.ts
+++ b/packages/backend/src/routes/files/DeleteFile.ts
@@ -32,7 +32,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	});
 
 	// Remove the file from disk
-	await deleteFile(file.name);
+	await deleteFile({ filename: file.name, isS3: file.isS3 });
 
 	return res.send({
 		message: 'Successfully deleted the file'

--- a/packages/backend/src/routes/files/GetFile.ts
+++ b/packages/backend/src/routes/files/GetFile.ts
@@ -49,7 +49,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	let parsedFile: ExtendedFile = file;
 	parsedFile = {
 		...file,
-		...constructFilePublicLink(req, file.name)
+		...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3 })
 	};
 
 	return res.send({

--- a/packages/backend/src/routes/files/GetFiles.ts
+++ b/packages/backend/src/routes/files/GetFiles.ts
@@ -34,7 +34,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			size: true,
 			type: true,
 			uuid: true,
-			quarantine: true
+			quarantine: true,
+			isS3: true
 		},
 		orderBy: {
 			id: 'desc'
@@ -45,7 +46,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink(req, file.name)
+			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3 })
 		});
 	}
 

--- a/packages/backend/src/routes/files/RegenerateFileThumbnail.ts
+++ b/packages/backend/src/routes/files/RegenerateFileThumbnail.ts
@@ -1,7 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { finished } from 'node:stream/promises';
+import { URL, fileURLToPath } from 'node:url';
 import type { FastifyReply } from 'fastify';
 import prisma from '@/structures/database.js';
 import type { RequestWithUser } from '@/structures/interfaces.js';
-import { generateThumbnails } from '@/utils/Thumbnails.js';
+import { SETTINGS } from '@/structures/settings.js';
+import { deleteTmpFile } from '@/utils/File.js';
+import { generateThumbnails, imageExtensions, videoExtensions } from '@/utils/Thumbnails.js';
 
 export const options = {
 	url: '/file/:uuid/thumbnail/regenerate',
@@ -19,7 +26,9 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			userId: req.user.id
 		},
 		select: {
-			name: true
+			name: true,
+			isS3: true,
+			size: true
 		}
 	});
 
@@ -28,7 +37,32 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		return;
 	}
 
-	void generateThumbnails(file.name);
+	if (file.isS3) {
+		const fileURL = `${SETTINGS.S3PublicUrl || SETTINGS.S3Endpoint}/${SETTINGS.S3Bucket}/${file.name}`;
+
+		const tmpDir = fileURLToPath(new URL('../../../../../uploads/tmp', import.meta.url));
+		const newPath = `${tmpDir}/${file.name}`;
+
+		const extension = path.extname(file.name);
+		const needsThumbnails = [...imageExtensions, ...videoExtensions].includes(extension);
+		const maxFileSizeForThumbnails = 100 * 1024 * 1024; // 100Mb
+
+		if (needsThumbnails && Number.parseInt(file.size, 10) <= maxFileSizeForThumbnails) {
+			try {
+				const fetchResponse = await fetch(fileURL);
+				if (!fetchResponse.body) return await res.internalServerError('Failed to fetch file');
+
+				// @ts-expect-error wrong types
+				await finished(Readable.fromWeb(fetchResponse.body).pipe(fs.createWriteStream(newPath)));
+			} catch (error) {
+				req.log.error(error);
+				void deleteTmpFile(newPath);
+				return res.internalServerError('Failed to fetch file');
+			}
+		}
+	}
+
+	void generateThumbnails(file.name, file.isS3);
 
 	return res.send({
 		message: 'Successfully regenerated file thumbnail'

--- a/packages/backend/src/routes/files/Search.ts
+++ b/packages/backend/src/routes/files/Search.ts
@@ -76,7 +76,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			original: true,
 			size: true,
 			type: true,
-			uuid: true
+			uuid: true,
+			isS3: true
 		},
 		orderBy: {
 			id: 'desc'
@@ -87,7 +88,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink(req, file.name)
+			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3 })
 		});
 	}
 

--- a/packages/backend/src/routes/files/UploadProcess.schema.ts
+++ b/packages/backend/src/routes/files/UploadProcess.schema.ts
@@ -1,15 +1,30 @@
 export default {
-	summary: 'Upload file',
-	description: 'Uploads a file',
+	summary: 'Process uploaded file',
+	description: 'Processes an uploaded file',
 	tags: ['Files'],
 	headers: {
 		type: 'object',
 		properties: {
-			albumuuid: { type: 'string' },
-			'chibi-chunk-number': { type: 'number' },
-			'chibi-chunks-total': { type: 'number' },
-			'chibi-uuid': { type: 'string' }
+			albumuuid: { type: 'string' }
 		}
+	},
+	body: {
+		type: 'object',
+		properties: {
+			identifier: {
+				type: 'string',
+				description: 'The identifier of the file.'
+			},
+			name: {
+				type: 'string',
+				description: 'The name of the file.'
+			},
+			type: {
+				type: 'string',
+				description: 'The type of the file.'
+			}
+		},
+		required: ['identifier', 'name', 'type']
 	},
 	response: {
 		200: {
@@ -28,24 +43,14 @@ export default {
 				url: {
 					type: 'string',
 					description: 'The URL of the file.',
-					example: 'https://chibisafe.moe/ks2vjph2hkc.png'
+					example: 'https://s3.amazonaws.com/chibisafe/ks2vjph2hkc.jpg'
 				},
 				identifier: {
 					type: 'string',
 					description: 'The identifier of the file.',
 					example: 'ks2vjph2hkc.jpg'
-				},
-				publicUrl: {
-					type: 'string',
-					description: 'The public URL of the file.',
-					example: 'https://s3.amazonaws.com/chibisafe/ks2vjph2hkc.jpg'
 				}
 			}
-		},
-		204: {
-			title: '204',
-			type: 'object',
-			properties: {}
 		},
 		'4xx': { $ref: 'HTTP4xxError' },
 		'5xx': { $ref: 'HTTP5xxError' }

--- a/packages/backend/src/routes/files/UploadProcess.ts
+++ b/packages/backend/src/routes/files/UploadProcess.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { finished } from 'node:stream/promises';
+import { URL, fileURLToPath } from 'node:url';
+import { DeleteObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import type { FastifyReply } from 'fastify';
+import type { RequestWithUser } from '@/structures/interfaces.js';
+import { SETTINGS } from '@/structures/settings.js';
+import { storeFileToDb, constructFilePublicLink, checkFileHashOnDB, deleteTmpFile } from '@/utils/File.js';
+import { generateThumbnails, imageExtensions, videoExtensions } from '@/utils/Thumbnails.js';
+import { validateAlbum } from '@/utils/UploadHelpers.js';
+
+export const options = {
+	url: '/upload/process',
+	method: 'post',
+	middlewares: [
+		{
+			name: 'apiKey'
+		},
+		{
+			name: 'auth',
+			optional: true
+		}
+	]
+};
+
+export const run = async (req: RequestWithUser, res: FastifyReply) => {
+	if (!SETTINGS.useNetworkStorage) return res.internalServerError('Network storage is not enabled');
+
+	const { identifier, name, type } = req.body as { identifier: string; name: string; type: string };
+	if (!identifier || !name || !type) return res.badRequest('Missing file identifier');
+
+	const { createS3Client } = await import('@/structures/s3.js');
+	const S3Client = createS3Client();
+
+	const album = await validateAlbum(req.headers.albumuuid as string, req.user ? req.user : undefined);
+	const fileURL = `${SETTINGS.S3PublicUrl || SETTINGS.S3Endpoint}/${SETTINGS.S3Bucket}/${identifier}`;
+
+	const tmpDir = fileURLToPath(new URL('../../../../../uploads/tmp', import.meta.url));
+	const newPath = `${tmpDir}/${identifier}`;
+
+	let fileSize = 0;
+	let hash = '';
+
+	try {
+		const command = new HeadObjectCommand({
+			Bucket: SETTINGS.S3Bucket,
+			Key: identifier
+		});
+
+		const response = await S3Client.send(command);
+		fileSize = response.ContentLength ?? 0;
+		hash = response.ETag?.replace(/"/g, '') ?? '';
+	} catch (error) {
+		req.log.error(error);
+		return res.internalServerError('Failed to fetch file');
+	}
+
+	const extension = path.extname(identifier);
+
+	const file = {
+		name: identifier,
+		extension,
+		path: newPath,
+		original: name,
+		type,
+		size: String(fileSize),
+		hash,
+		ip: req.ip,
+		isS3: true
+	};
+
+	let uploadedFile;
+	const fileOnDb = await checkFileHashOnDB(req.user, file);
+	if (fileOnDb?.repeated) {
+		uploadedFile = fileOnDb.file;
+		await deleteTmpFile(newPath);
+
+		const command = new DeleteObjectCommand({
+			Bucket: SETTINGS.S3Bucket,
+			Key: identifier
+		});
+
+		await S3Client.send(command);
+	} else {
+		// Store file in database
+		const savedFile = await storeFileToDb(req.user ? req.user : undefined, file, album ? album : undefined);
+
+		uploadedFile = savedFile.file;
+
+		// Generate thumbnails
+		const needsThumbnails = [...imageExtensions, ...videoExtensions].includes(extension);
+		const maxFileSizeForThumbnails = 100 * 1024 * 1024; // 100Mb
+
+		if (needsThumbnails && fileSize <= maxFileSizeForThumbnails) {
+			fetch(fileURL)
+				// eslint-disable-next-line promise/prefer-await-to-then
+				.then(async res => {
+					if (!res.body) throw new Error('Failed to fetch file');
+
+					// @ts-expect-error wrong types
+					await finished(Readable.fromWeb(res.body).pipe(fs.createWriteStream(newPath)));
+				})
+				// eslint-disable-next-line promise/prefer-await-to-then
+				.then(() => {
+					void generateThumbnails(savedFile.file.name, true);
+				})
+				// eslint-disable-next-line promise/prefer-await-to-callbacks, promise/prefer-await-to-then
+				.catch(error => {
+					req.log.error(error);
+					void deleteTmpFile(newPath);
+				});
+		}
+	}
+
+	const linkData = constructFilePublicLink({ req, fileName: uploadedFile.name, isS3: true });
+	// Construct public link
+	const fileWithLink = {
+		...uploadedFile,
+		...linkData
+	};
+
+	await res.code(200).send(fileWithLink);
+};

--- a/packages/backend/src/routes/tag/GetTag.ts
+++ b/packages/backend/src/routes/tag/GetTag.ts
@@ -36,7 +36,8 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 					original: true,
 					size: true,
 					type: true,
-					uuid: true
+					uuid: true,
+					isS3: true
 				},
 				orderBy: {
 					id: 'desc'
@@ -58,7 +59,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		const modifiedFile = file as unknown as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLink(req, modifiedFile.name)
+			...constructFilePublicLink({ req, fileName: modifiedFile.name, isS3: modifiedFile.isS3 })
 		});
 	}
 

--- a/packages/backend/src/structures/interfaces.ts
+++ b/packages/backend/src/structures/interfaces.ts
@@ -40,6 +40,7 @@ export interface FileInProgress {
 	field?: string;
 	hash: string;
 	ip: string;
+	isS3: boolean;
 	name: string;
 	original: string;
 	path: string;
@@ -52,6 +53,7 @@ export interface File {
 	editedAt: Date | null;
 	hash: string;
 	ip: string;
+	isS3: boolean;
 	name: string;
 	original: string;
 	quarantine: boolean;
@@ -103,6 +105,12 @@ export interface Album {
 export interface Settings {
 	// savedStatistics: string[];
 	[key: string]: string[] | boolean | number | string;
+	S3AccessKey: string;
+	S3Bucket: string;
+	S3Endpoint: string;
+	S3PublicUrl: string;
+	S3Region: string;
+	S3SecretKey: string;
 	backgroundImageURL: string;
 	blockNoExtension: boolean;
 	blockedExtensions: string[];
@@ -130,6 +138,7 @@ export interface Settings {
 	serviceName: string;
 	statisticsCron: string;
 	updateCheckCron: string;
+	useNetworkStorage: boolean;
 	userAccounts: boolean;
 	usersStorageQuota: number;
 }

--- a/packages/backend/src/structures/s3.ts
+++ b/packages/backend/src/structures/s3.ts
@@ -1,0 +1,18 @@
+import { S3Client, type S3ClientConfig } from '@aws-sdk/client-s3';
+import { SETTINGS } from './settings.js';
+
+export const createS3Client = () => {
+	const config: S3ClientConfig = {
+		region: SETTINGS.S3Region,
+		credentials: {
+			accessKeyId: SETTINGS.S3AccessKey,
+			secretAccessKey: SETTINGS.S3SecretKey
+		}
+	};
+
+	if (SETTINGS.S3Endpoint) {
+		config.endpoint = SETTINGS.S3Endpoint;
+	}
+
+	return new S3Client(config);
+};

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -62,6 +62,13 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.metaTwitterHandle = settingsTable.metaTwitterHandle;
 		SETTINGS.metaDomain = settingsTable.metaDomain;
 		SETTINGS.usersStorageQuota = Number(settingsTable.usersStorageQuota);
+		SETTINGS.useNetworkStorage = settingsTable.useNetworkStorage;
+		SETTINGS.S3Region = settingsTable.S3Region;
+		SETTINGS.S3Bucket = settingsTable.S3Bucket;
+		SETTINGS.S3AccessKey = settingsTable.S3AccessKey;
+		SETTINGS.S3SecretKey = settingsTable.S3SecretKey;
+		SETTINGS.S3Endpoint = settingsTable.S3Endpoint;
+		SETTINGS.S3PublicUrl = settingsTable.S3PublicUrl;
 		return;
 	}
 
@@ -92,7 +99,14 @@ export const loadSettings = async (force = false) => {
 		metaDescription: 'description for please-change-me.com 🚀',
 		metaKeywords: 'comma, separated, keywords, that, describe, this, website',
 		metaTwitterHandle: '@your-twitter-handle',
-		usersStorageQuota: 0
+		usersStorageQuota: 0,
+		useNetworkStorage: false,
+		S3Region: '',
+		S3Bucket: '',
+		S3AccessKey: '',
+		S3SecretKey: '',
+		S3Endpoint: '',
+		S3PublicUrl: ''
 	};
 
 	await prisma.settings.create({
@@ -294,5 +308,48 @@ const SETTINGS_META = {
 		name: 'Users Storage Quota',
 		notice: "You can override this setting by changing it on a user's profile.",
 		category: 'users'
+	},
+	useNetworkStorage: {
+		type: 'boolean',
+		description: 'Whether or not to use network storage like S3/Backblaze/Wasabi.',
+		name: 'Use Network Storage',
+		category: 'uploads'
+	},
+	S3Region: {
+		type: 'string',
+		description: 'The region for the S3 bucket.',
+		name: 'S3 Region',
+		category: 'uploads'
+	},
+	S3Bucket: {
+		type: 'string',
+		description: 'The name of the S3 bucket.',
+		name: 'S3 Bucket',
+		category: 'uploads'
+	},
+	S3AccessKey: {
+		type: 'string',
+		description: 'The accesss key for the S3 bucket.',
+		name: 'S3 Access Key',
+		category: 'uploads'
+	},
+	S3SecretKey: {
+		type: 'string',
+		description: 'The secret key for the S3 bucket.',
+		name: 'S3 Secret Key',
+		category: 'uploads'
+	},
+	S3Endpoint: {
+		type: 'string',
+		description: 'The endpoint for the S3 bucket.',
+		name: 'S3 Endpoint',
+		category: 'uploads'
+	},
+	S3PublicUrl: {
+		type: 'string',
+		description: 'The public URL for the S3 bucket. Only provide it for AWS S3.',
+		name: 'S3 Public URL',
+		example: 'https://s3.amazonaws.com',
+		category: 'uploads'
 	}
 };

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,10 +25,10 @@
 		"url": "https://github.com/WeebDev/chibisafe/issues"
 	},
 	"engines": {
-		"node": ">=16.0.0"
+		"node": ">=18.9.0"
 	},
 	"dependencies": {
-		"@chibisafe/uploader-client": "1.0.10",
+		"@chibisafe/uploader-client": "1.0.11",
 		"@headlessui/vue": "^1.7.16",
 		"@tanstack/vue-query": "^5.17.1",
 		"@types/marked": "^6.0.0",
@@ -92,9 +92,6 @@
 		"file uploader",
 		"images"
 	],
-	"volta": {
-		"node": "18.9.0"
-	},
 	"eslintIgnore": [
 		"components.d.ts"
 	]

--- a/packages/frontend/src/store/settings.ts
+++ b/packages/frontend/src/store/settings.ts
@@ -10,7 +10,8 @@ export const useSettingsStore = defineStore('settings', {
 		backgroundImageURL: '',
 		publicMode: false,
 		userAccounts: false,
-		blockedExtensions: ['']
+		blockedExtensions: [''],
+		useNetworkStorage: false
 	}),
 	actions: {
 		async get() {
@@ -25,6 +26,7 @@ export const useSettingsStore = defineStore('settings', {
 			this.publicMode = response.publicMode;
 			this.userAccounts = response.userAccounts;
 			this.blockedExtensions = response.blockedExtensions;
+			this.useNetworkStorage = response.useNetworkStorage;
 		}
 	}
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,734 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/crc32@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 9fdb3e837fc54119b017ea34fd0a6d71d2c88075d99e1e818a5158e0ad30ced67ddbcc423a11ceeef6cc465ab5ffd91830acab516470b48237ca7abd51be9642
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32c@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32c@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 0a116b5d1c5b09a3dde65aab04a07b32f543e87b68f2d175081e3f4a1a17502343f223d691dd883ace1ddce65cd40093673e7c7415dcd99062202ba87ffb4038
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/ie11-detection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 299b2ddd46eddac1f2d54d91386ceb37af81aef8a800669281c73d634ed17fd855dcfb8b3157f2879344b93a2666a6d602550eb84b71e4d7868100ad6da8f803
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha1-browser@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^3.0.0
+    "@aws-crypto/supports-web-crypto": ^3.0.0
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 78c379e105a0c4e7b2ed745dffd8f55054d7dde8b350b61de682bbc3cd081a50e2f87861954fa9cd53c7ea711ebca1ca0137b14cb36483efc971f60f573cf129
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^3.0.0
+    "@aws-crypto/sha256-js": ^3.0.0
+    "@aws-crypto/supports-web-crypto": ^3.0.0
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: ca89456bf508db2e08060a7f656460db97ac9a15b11e39d6fa7665e2b156508a1758695bff8e82d0a00178d6ac5c36f35eb4bcfac2e48621265224ca14a19bd2
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-js@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 644ded32ea310237811afae873d3c7320739cb6f6cc39dced9c94801379e68e5ee2cca0c34f0384793fa9e750a7e0a5e2468f95754bd08e6fd72ab833c8fe23c
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:3.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 35479a1558db9e9a521df6877a99f95670e972c602f2a0349303477e5d638a5baf569fb037c853710e382086e6fd77e8ed58d3fb9b49f6e1186a9d26ce7be006
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/util@npm:3.0.0"
+  dependencies:
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: d29d5545048721aae3d60b236708535059733019a105f8a64b4e4a8eab7cf8dde1546dc56bff7de20d36140a4d1f0f4693e639c5732a7059273a7b1e56354776
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/client-s3@npm:3.504.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": 3.0.0
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.504.0
+    "@aws-sdk/core": 3.496.0
+    "@aws-sdk/credential-provider-node": 3.504.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.502.0
+    "@aws-sdk/middleware-expect-continue": 3.502.0
+    "@aws-sdk/middleware-flexible-checksums": 3.502.0
+    "@aws-sdk/middleware-host-header": 3.502.0
+    "@aws-sdk/middleware-location-constraint": 3.502.0
+    "@aws-sdk/middleware-logger": 3.502.0
+    "@aws-sdk/middleware-recursion-detection": 3.502.0
+    "@aws-sdk/middleware-sdk-s3": 3.502.0
+    "@aws-sdk/middleware-signing": 3.502.0
+    "@aws-sdk/middleware-ssec": 3.502.0
+    "@aws-sdk/middleware-user-agent": 3.502.0
+    "@aws-sdk/region-config-resolver": 3.502.0
+    "@aws-sdk/signature-v4-multi-region": 3.502.0
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-endpoints": 3.502.0
+    "@aws-sdk/util-user-agent-browser": 3.502.0
+    "@aws-sdk/util-user-agent-node": 3.502.0
+    "@aws-sdk/xml-builder": 3.496.0
+    "@smithy/config-resolver": ^2.1.1
+    "@smithy/core": ^1.3.1
+    "@smithy/eventstream-serde-browser": ^2.1.1
+    "@smithy/eventstream-serde-config-resolver": ^2.1.1
+    "@smithy/eventstream-serde-node": ^2.1.1
+    "@smithy/fetch-http-handler": ^2.4.1
+    "@smithy/hash-blob-browser": ^2.1.1
+    "@smithy/hash-node": ^2.1.1
+    "@smithy/hash-stream-node": ^2.1.1
+    "@smithy/invalid-dependency": ^2.1.1
+    "@smithy/md5-js": ^2.1.1
+    "@smithy/middleware-content-length": ^2.1.1
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/middleware-retry": ^2.1.1
+    "@smithy/middleware-serde": ^2.1.1
+    "@smithy/middleware-stack": ^2.1.1
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/node-http-handler": ^2.3.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/url-parser": ^2.1.1
+    "@smithy/util-base64": ^2.1.1
+    "@smithy/util-body-length-browser": ^2.1.1
+    "@smithy/util-body-length-node": ^2.2.1
+    "@smithy/util-defaults-mode-browser": ^2.1.1
+    "@smithy/util-defaults-mode-node": ^2.1.1
+    "@smithy/util-endpoints": ^1.1.1
+    "@smithy/util-retry": ^2.1.1
+    "@smithy/util-stream": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    "@smithy/util-waiter": ^2.1.1
+    fast-xml-parser: 4.2.5
+    tslib: ^2.5.0
+  checksum: 22f4bb61196d5a567295e4ad42248f132a5e16ed1eb66bee9fcb7273dad13a9c3a2ebe5b2fb4277e645ede8b0650ddb2665fd450018b56cc29650dbd5d6ce427
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso-oidc@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.504.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.504.0
+    "@aws-sdk/core": 3.496.0
+    "@aws-sdk/middleware-host-header": 3.502.0
+    "@aws-sdk/middleware-logger": 3.502.0
+    "@aws-sdk/middleware-recursion-detection": 3.502.0
+    "@aws-sdk/middleware-signing": 3.502.0
+    "@aws-sdk/middleware-user-agent": 3.502.0
+    "@aws-sdk/region-config-resolver": 3.502.0
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-endpoints": 3.502.0
+    "@aws-sdk/util-user-agent-browser": 3.502.0
+    "@aws-sdk/util-user-agent-node": 3.502.0
+    "@smithy/config-resolver": ^2.1.1
+    "@smithy/core": ^1.3.1
+    "@smithy/fetch-http-handler": ^2.4.1
+    "@smithy/hash-node": ^2.1.1
+    "@smithy/invalid-dependency": ^2.1.1
+    "@smithy/middleware-content-length": ^2.1.1
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/middleware-retry": ^2.1.1
+    "@smithy/middleware-serde": ^2.1.1
+    "@smithy/middleware-stack": ^2.1.1
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/node-http-handler": ^2.3.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/url-parser": ^2.1.1
+    "@smithy/util-base64": ^2.1.1
+    "@smithy/util-body-length-browser": ^2.1.1
+    "@smithy/util-body-length-node": ^2.2.1
+    "@smithy/util-defaults-mode-browser": ^2.1.1
+    "@smithy/util-defaults-mode-node": ^2.1.1
+    "@smithy/util-endpoints": ^1.1.1
+    "@smithy/util-retry": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-sdk/credential-provider-node": ^3.504.0
+  checksum: 93e816246e1f3ebf00c696f9f1cc2b3afd8c49ffc67020ce8aba0e752051afce4bfe9521bf6f4ad8dc55eeef5d320a903353829704215ec5838bbc08ec48974c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/client-sso@npm:3.502.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/core": 3.496.0
+    "@aws-sdk/middleware-host-header": 3.502.0
+    "@aws-sdk/middleware-logger": 3.502.0
+    "@aws-sdk/middleware-recursion-detection": 3.502.0
+    "@aws-sdk/middleware-user-agent": 3.502.0
+    "@aws-sdk/region-config-resolver": 3.502.0
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-endpoints": 3.502.0
+    "@aws-sdk/util-user-agent-browser": 3.502.0
+    "@aws-sdk/util-user-agent-node": 3.502.0
+    "@smithy/config-resolver": ^2.1.1
+    "@smithy/core": ^1.3.1
+    "@smithy/fetch-http-handler": ^2.4.1
+    "@smithy/hash-node": ^2.1.1
+    "@smithy/invalid-dependency": ^2.1.1
+    "@smithy/middleware-content-length": ^2.1.1
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/middleware-retry": ^2.1.1
+    "@smithy/middleware-serde": ^2.1.1
+    "@smithy/middleware-stack": ^2.1.1
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/node-http-handler": ^2.3.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/url-parser": ^2.1.1
+    "@smithy/util-base64": ^2.1.1
+    "@smithy/util-body-length-browser": ^2.1.1
+    "@smithy/util-body-length-node": ^2.2.1
+    "@smithy/util-defaults-mode-browser": ^2.1.1
+    "@smithy/util-defaults-mode-node": ^2.1.1
+    "@smithy/util-endpoints": ^1.1.1
+    "@smithy/util-retry": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: ef801b4838af20d0d0458b02f0ca8ecb1e08ab1a8c1fe885b446745f730aee1e8a4fd1cbc555a7628390f67955d6d62b06f57f426551210356414f3c15cdd084
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/client-sts@npm:3.504.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/core": 3.496.0
+    "@aws-sdk/middleware-host-header": 3.502.0
+    "@aws-sdk/middleware-logger": 3.502.0
+    "@aws-sdk/middleware-recursion-detection": 3.502.0
+    "@aws-sdk/middleware-user-agent": 3.502.0
+    "@aws-sdk/region-config-resolver": 3.502.0
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-endpoints": 3.502.0
+    "@aws-sdk/util-user-agent-browser": 3.502.0
+    "@aws-sdk/util-user-agent-node": 3.502.0
+    "@smithy/config-resolver": ^2.1.1
+    "@smithy/core": ^1.3.1
+    "@smithy/fetch-http-handler": ^2.4.1
+    "@smithy/hash-node": ^2.1.1
+    "@smithy/invalid-dependency": ^2.1.1
+    "@smithy/middleware-content-length": ^2.1.1
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/middleware-retry": ^2.1.1
+    "@smithy/middleware-serde": ^2.1.1
+    "@smithy/middleware-stack": ^2.1.1
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/node-http-handler": ^2.3.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/url-parser": ^2.1.1
+    "@smithy/util-base64": ^2.1.1
+    "@smithy/util-body-length-browser": ^2.1.1
+    "@smithy/util-body-length-node": ^2.2.1
+    "@smithy/util-defaults-mode-browser": ^2.1.1
+    "@smithy/util-defaults-mode-node": ^2.1.1
+    "@smithy/util-endpoints": ^1.1.1
+    "@smithy/util-middleware": ^2.1.1
+    "@smithy/util-retry": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    fast-xml-parser: 4.2.5
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-sdk/credential-provider-node": ^3.504.0
+  checksum: f13bd125c5a5f4bf75945c4bb72b2e4e27eec5d666e3fed81014b86f4abbed6b4751bf74448d35e361bab2fb45c1574908e3354ff09d474a64392deeb05f7150
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:3.496.0":
+  version: 3.496.0
+  resolution: "@aws-sdk/core@npm:3.496.0"
+  dependencies:
+    "@smithy/core": ^1.3.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/signature-v4": ^2.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 6c83bc1092dbbf63e55d8df6630873f9088301b18a258866fa45e1b0aff8d90e77528612467e0cf3dcc24413f978762d8232e23f725c2a5385c7cb345464b178
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 9a638955f1fc6bd07c6fe9c749cfea42867b4baf87caa8228e1203f856c989adac235ca1ee5c236d4819c973c44723f46e65bbc957843f025f40c6e24f69d65e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.503.1":
+  version: 3.503.1
+  resolution: "@aws-sdk/credential-provider-http@npm:3.503.1"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/fetch-http-handler": ^2.4.1
+    "@smithy/node-http-handler": ^2.3.1
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-stream": ^2.1.1
+    tslib: ^2.5.0
+  checksum: c4a6f7fc06a11071987ed803a4ce40c52ad077cbdd0171161030ecb157a76710e1bc95bb9c36acc4f01d32ab82c4c11620bb843d88c61027c011361205537bea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.504.0"
+  dependencies:
+    "@aws-sdk/client-sts": 3.504.0
+    "@aws-sdk/credential-provider-env": 3.502.0
+    "@aws-sdk/credential-provider-process": 3.502.0
+    "@aws-sdk/credential-provider-sso": 3.504.0
+    "@aws-sdk/credential-provider-web-identity": 3.504.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/credential-provider-imds": ^2.2.1
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: b8a2b56ee7109608c74b97a0fa7c52759d11b4754e81b4fd32a178d9e2ee2ea4c334e31a657b2f10d042da30f53f7e6003d87c6e4a13f517e6d5d4afaa8fba20
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.504.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.502.0
+    "@aws-sdk/credential-provider-http": 3.503.1
+    "@aws-sdk/credential-provider-ini": 3.504.0
+    "@aws-sdk/credential-provider-process": 3.502.0
+    "@aws-sdk/credential-provider-sso": 3.504.0
+    "@aws-sdk/credential-provider-web-identity": 3.504.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/credential-provider-imds": ^2.2.1
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 5d36589c7755313992013c8d2d776f2ab919a1d528eb17ed32d869869595d941d3e0e533e80bc2ea7b49a94fd80f205a4438aba5e5eabfc0a8f4717665490a59
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 418a22b5ab08d73b68246e9abc79ebbdc93ca84319dff21f2354af93b157cf798551e7c47a123f9c65e18b2fd1f88987be451914e544b9f74ae5fcdf7fed0437
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.504.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.502.0
+    "@aws-sdk/token-providers": 3.504.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: e3716422ef27e6aa6d50a9e85809c2e51b2f7a3d8bddc4b1b0d61a5cfce2ccb2c7503e9319498861f57b05557027fe59863b3ee292601321b7fb80d772027ddb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.504.0"
+  dependencies:
+    "@aws-sdk/client-sts": 3.504.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: daf3c44b6663cd3e63634fce953c8ddd409640f53462c6e625de9b238b98dfc288776264990957f06f3134a6ba96dabd16e82cd7150d5c2579bcc625f9d2933d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-bucket-endpoint@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-arn-parser": 3.495.0
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-config-provider": ^2.2.1
+    tslib: ^2.5.0
+  checksum: cb1f7e61ada2340d62efcfe7e90814f32dbb983139844a00859d767f09cd8201c4b92b9afd5b391e8ca1b5c8318bb998ab93c5bb7baa4cdbe6bfc2cc021cbb66
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-expect-continue@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: ef05feafa08721790f969518ceebd6bc78221732557747821665f5148dc979b32820c8c6158feea1cc696c38a1d55c4ab9e835aba3d8ffe84113ea1f0a4df934
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.502.0"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@aws-crypto/crc32c": 3.0.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/is-array-buffer": ^2.1.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: d0615350823b8b4e3f07d4c200d7fa04313ca50c33a6caed0bd794bdde75cf758b73887fd1bf04dd64272e96a2500d2acb59fd5b8a5d828b87f7e0c514756a5f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 4e55ee901f31b4372a82a0ed429912d96c07369353ab914fd05a2caf1e64fc22288d4214bcec99b36eb1e9336944718267f95a9be87653baac3a7c2365b99663
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-location-constraint@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: fdcfb1186cb53b4587b1ca3aa73f4160b2af3643006fcd1d68b41a0acfee4a80457140eefdbaee077da826397682d012ace06faacdbc8bff288831e96a735dc2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: ff8b754373c90e1c5baacf1e2f36b568602d2d1d2aa74da818516fbc6b49acd024204332cb950453b60d3f352b0e2d6c4c1f72b71662f953178a3e069a187681
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 75a4d712b04c63d649e026fe83d252a9c825ca0500042dcd83ad3cdaa58df4c5c25d645206200cbc119f3e7e48dbdb2cccd86f255a699cfa7f8cf155acaac6e4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-arn-parser": 3.495.0
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/signature-v4": ^2.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-config-provider": ^2.2.1
+    tslib: ^2.5.0
+  checksum: 6d27f5a82c30a1dadaefdbc89cd3eb3e08afc1fb1c627028e2bce2ac22e12bc035ecc8fc3578322386341266c4e801ac410091f38bc6dee5274be8ac0ec5dc39
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/signature-v4": ^2.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-middleware": ^2.1.1
+    tslib: ^2.5.0
+  checksum: b7595c3db33a62873fa29a8f08a64aca77f484035b42b5e12a8c364e2166b3dd81b1e3443bc3df5c97aaf3e00f14c2b99a8ef34cb3c132118d1e1872a74219e2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-ssec@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 0be54e13645bc97c130c61b09abb263def67e03382296aa020c118c672fef39359fddd997d2820ae62cbaeaa34d653ccafe0dfbb06a720e3b02d87e05b217e0f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-endpoints": 3.502.0
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: a65559d5cb790af73d75400099a2d0b38857cd28f8eb9e81f9250c59bd17a1a0e4c4210aeeb94ceb67716af996bd00655de11456ff73424f50597f6f05d4622d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-config-provider": ^2.2.1
+    "@smithy/util-middleware": ^2.1.1
+    tslib: ^2.5.0
+  checksum: a13ee3502015baee3f8897a2597ea1ade556da0fcda653344e06624fd65e78fcc91a1b0b49edd4008760cb4284fb0cece1c44ea052cd4a7dca4bb01fb83bffd2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/s3-request-presigner@npm:^3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.504.0"
+  dependencies:
+    "@aws-sdk/signature-v4-multi-region": 3.502.0
+    "@aws-sdk/types": 3.502.0
+    "@aws-sdk/util-format-url": 3.502.0
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 6d2bff82713110e85ff24d76928041d7b384f16ac91d4685526016172cb409122f8ac5dda59c43665aeef49db55c9b399dff2e5b2340183c73b1e86f50d50a67
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3": 3.502.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/signature-v4": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 745bab5b1daa45b30d62ec3b1939c766fcff42104539b8466245c7b5b7e538c827dd5cdd6c65dbdd8dfe1e7261bffb208729a225b242e4bb2f91df78a0c72a67
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.504.0":
+  version: 3.504.0
+  resolution: "@aws-sdk/token-providers@npm:3.504.0"
+  dependencies:
+    "@aws-sdk/client-sso-oidc": 3.504.0
+    "@aws-sdk/types": 3.502.0
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: efdda4b1d1976085f2fa3f3733cfc644f8a9a66f07e76e3b250d27b66a4c25ce2e9bfd526b2a7041d9c683d5535d445b7ab511eb3ecefe67376318d019b5e224
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.502.0, @aws-sdk/types@npm:^3.222.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/types@npm:3.502.0"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 11dddc2c1fb7b601adba1df6339b68367a3c77fcdd298c7ceb42541c813ba777ffc9ddfbb68633f9fd9082c883edf1b2fe3139acdf822d7d423c0b5f76ce78dd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:3.495.0":
+  version: 3.495.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.495.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 130f1b1c0d2b9917782049693aa4ab6aec98858d6e2b46c14a3a6c4979e65073f731aec96aa0e1c04e927d0b32ad2d4a6a701e2a6d5d416c6ea35e670e4eb987
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/types": ^2.9.1
+    "@smithy/util-endpoints": ^1.1.1
+    tslib: ^2.5.0
+  checksum: 051b519c118ef28dd49d60efc21dd3c0a2b032f8b70fdedc831e6c747bd675d51edc3913630ab86a02ecda7a3ea3ea5bec87b20c756700e65e059e2307110859
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-format-url@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/util-format-url@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/querystring-builder": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: b9c8a4749955cf0aaf2d3cea3edf09a98891dcf1553dce3cde3420f614ee21705f4d12e6682ac4ca3121cf3cf2f31da815e63596d5f58a3e6c29c875cdb1f921
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.495.0
+  resolution: "@aws-sdk/util-locate-window@npm:3.495.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 73c5fc3199207f8ea19f07668c9412929eca36d91b12ca36212317f78cc0d47afb39a5a5112bee62a0dd62d05c87b22ebb40de23b9dc5efb0d6117d755a00ce0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/types": ^2.9.1
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: 89e4d26f79979f30e7b1285b4f073a65c76021b706ab5c7342e2f4e46b6a045cc353dfce9bca98c9d134e92767f1bc3270e9c485d10a0d37e9ec81c21656c2e5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.502.0":
+  version: 3.502.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.502.0"
+  dependencies:
+    "@aws-sdk/types": 3.502.0
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: b90a373d489bd34ce759acb76c91902bb2bd5991aad6a2d316d0b14c86bd7de659d85e9964111fc2e4bc76e67e19fd0d91ebe255e011c1054ca813c97992cc43
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.259.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.259.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:3.496.0":
+  version: 3.496.0
+  resolution: "@aws-sdk/xml-builder@npm:3.496.0"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 42d9d60c1c7f8a22f6a64ac36ba9d5ccff200ce963beebb142ad4708d2486fe29b61ecb37bbccd6f0019e25107aa2327e6d8550d30214b4895e7219ccb8661c8
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.16.0, @babel/code-frame@npm:^7.22.13":
   version: 7.22.13
   resolution: "@babel/code-frame@npm:7.22.13"
@@ -258,6 +986,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chibisafe/backend@workspace:packages/backend"
   dependencies:
+    "@aws-sdk/client-s3": ^3.504.0
+    "@aws-sdk/s3-request-presigner": ^3.504.0
     "@chibisafe/uploader-module": 1.0.10
     "@fastify/cors": ^8.5.0
     "@fastify/helmet": ^11.1.1
@@ -333,12 +1063,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chibisafe/uploader-client@npm:1.0.10":
-  version: 1.0.10
-  resolution: "@chibisafe/uploader-client@npm:1.0.10"
+"@chibisafe/uploader-client@npm:1.0.11":
+  version: 1.0.11
+  resolution: "@chibisafe/uploader-client@npm:1.0.11"
   dependencies:
     uuid: ^9.0.1
-  checksum: b001199ec35f3c1b871f0296728e0919e23a21126a4dad1fc3c19a3baf7090d519a1a13c35632971abff74b952ffb66188ead9c18d825d224cd139365dfb7e41
+  checksum: c18c233b7cbda0db8581e16b2c903e067220e0181ea85bcd07ad6ccaf043f4bbd400dc81db98d86f26b0c24dfd33a16472731da407d0a62a6774c8cb01288b58
   languageName: node
   linkType: hard
 
@@ -357,7 +1087,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chibisafe/website@workspace:packages/frontend"
   dependencies:
-    "@chibisafe/uploader-client": 1.0.10
+    "@chibisafe/uploader-client": 1.0.11
     "@headlessui/vue": ^1.7.16
     "@playwright/test": ^1.40.1
     "@tailwindcss/forms": ^0.5.7
@@ -1429,6 +2159,570 @@ __metadata:
   version: 1.6.1
   resolution: "@rushstack/eslint-patch@npm:1.6.1"
   checksum: d0c0fcc430dae71d9d929e593844aeaec8d326b1d6c27f18059e22dad486d8df43d6f0206b2021a0df789baf514642355bd86eae7a42c457b7b2f48a29bb0f53
+  languageName: node
+  linkType: hard
+
+"@smithy/abort-controller@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/abort-controller@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 4bfad0d6b3a75bd1e6f997aa41cc9d8ba8bfdf548cfe703553ad7b42f0bf3e06b595d584be7b9ab90d2e3b22aacad94c02c32e21bea96e46933443f09c59523a
+  languageName: node
+  linkType: hard
+
+"@smithy/chunked-blob-reader-native@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/chunked-blob-reader-native@npm:2.1.1"
+  dependencies:
+    "@smithy/util-base64": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 82f475b9090e12306292d46b27cca841691a251db5c9b5520830f7e5c947bbe69b497619773b25754dcdd8580620fd3677f478e1325501549f6182d78e95c583
+  languageName: node
+  linkType: hard
+
+"@smithy/chunked-blob-reader@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/chunked-blob-reader@npm:2.1.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: e9d7f6f80fffccb5b615aa4eecf0e48849e625a70a79acc371b74b3d5e6dffed3b0d21d8beafe2e1cc1ebc235b8c24ed7d7e31e8c3565d97efe1238dda82c813
+  languageName: node
+  linkType: hard
+
+"@smithy/config-resolver@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/config-resolver@npm:2.1.1"
+  dependencies:
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-config-provider": ^2.2.1
+    "@smithy/util-middleware": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 18c8af60cbc528887a82dc0eabaf0b398d868511dc6b10fa01f41c77ea9c2679ab2137feaee51aa9060dbc5c46fc33325a659f4bd54549c203f64e15dbacbc0a
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@smithy/core@npm:1.3.1"
+  dependencies:
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/middleware-retry": ^2.1.1
+    "@smithy/middleware-serde": ^2.1.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-middleware": ^2.1.1
+    tslib: ^2.5.0
+  checksum: b8a34ac6000afaba2d3ddf85f3ef2ad9e70fc20ae54ccb7e79d22b7afe3b8fa9c2409ed14dd2d0cabc99a1d1f51fceaf91ab81d1d2c8bf11ca94101619f3cde2
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@smithy/credential-provider-imds@npm:2.2.1"
+  dependencies:
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/url-parser": ^2.1.1
+    tslib: ^2.5.0
+  checksum: a4e693719384440718728772ea2126be133bbc83fa7bfcefd236942ccb28d1390f1b32fe3262bf330ba4c8e600d01ac73a57110eb42462ec1eb6bbd51e2676a6
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/eventstream-codec@npm:2.1.1"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@smithy/types": ^2.9.1
+    "@smithy/util-hex-encoding": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 7e59028a69e669d1ca1a0fef788f9892a427fad32f33ded731cbfa3bde0163acbc1e7d207e0ce3eae2d3b53f48dce7a99ded092122cdf78e4f392cffd762bfe3
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-browser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/eventstream-serde-browser@npm:2.1.1"
+  dependencies:
+    "@smithy/eventstream-serde-universal": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: c909b620de25e9779653742012c665df8c76bf5193bb79054ef302bc3c08b0fa5620884a5965a3a6ebbb4f059da1b05221662a7a652aa979f4830f26c534be60
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-config-resolver@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 14d4d1c638be460290eb05dec3a700d742f8ce77814c1c235fbd7cf248941a387595f1cd684b9acfc3e081a8d9e6dc2810f10c894b3e08f16f0c3adb130cb736
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-node@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/eventstream-serde-node@npm:2.1.1"
+  dependencies:
+    "@smithy/eventstream-serde-universal": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 4be3dd11854d66310273bae07faafd4ca872158be8d3ef7bdc1dec55a175e983975750ebdaf762e74daf80495e379bd2791971a50899076865759a75b2634d73
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-universal@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/eventstream-serde-universal@npm:2.1.1"
+  dependencies:
+    "@smithy/eventstream-codec": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 99c7cf5b869f8e6323e976335a3238b77d3b1c32005fc78093d448981883294e4d59bcbd419e88d6a53c76aab01c27bc9af63a5dfed9451d2302eaf6ccddbd64
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "@smithy/fetch-http-handler@npm:2.4.1"
+  dependencies:
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/querystring-builder": ^2.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-base64": ^2.1.1
+    tslib: ^2.5.0
+  checksum: c23701d45bca6842b5206939ccd587e3482ace9f656ae3dca92ff0bad3fefb846cc33683dff41a19186f2a5662ca6cd66c8aefda4664b7dfd95f9a616055a1c1
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-blob-browser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/hash-blob-browser@npm:2.1.1"
+  dependencies:
+    "@smithy/chunked-blob-reader": ^2.1.1
+    "@smithy/chunked-blob-reader-native": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: f4dc57c11ef32ddea0e7094d2c230aa274f1e410d84c789d8f5e2ed8a090da8675ca76da9605d297285324107ea8106af1c2aab2859bd62d6e9a8db415eb8e55
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-node@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/hash-node@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    "@smithy/util-buffer-from": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 5d5aae69b94dcb8abaf9f6a5b53ee320c9e126445c4540fcf2169e8ea7ebd953acff7fd77ba514614f6ebbb0baf412e878eebcc3427a5b9b6f8ee39abbc59230
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-stream-node@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/hash-stream-node@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: da3c4ba14c648ee0d2fe7d3298d601150ee0ce5ac0c7d9f54a88148b5f67b03513b41560f76f5f109f11196547b4dc4f26e314774794596d7e3ee1103a9906a8
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/invalid-dependency@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: f95ecd9acd337a408b6608a3f451b24a61e26149878f61fc7855c724888f0d28abf0b798d16990dadb7eafc8027098f934c0cd44e75d01d31617bd1fbfd93935
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/is-array-buffer@npm:2.1.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 5dbf9ed59715c871321d0624e3842340c1d662d2e8b78313d1658d39eb793b3ac5c379d573eba0a2ca3add9b313848d4d93fd04bb8565c75fbab749928b239a6
+  languageName: node
+  linkType: hard
+
+"@smithy/md5-js@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/md5-js@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: d15bc426a46d80d450b555a5ccd3d5a6bf37190f4b9ccb705852cd53ce61e4fe6fb08a569b87303ee787da57023f2b75f0e7893644af16c89e9aaf513f8afff3
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-content-length@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/middleware-content-length@npm:2.1.1"
+  dependencies:
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: cb0ea801f72a1a01f5956b3526df930fc19762b07d43a3871ff29815f621603410753d37710d72675d9761b93da32a38cfd5195582de8b6a47e299b1f073be25
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "@smithy/middleware-endpoint@npm:2.4.1"
+  dependencies:
+    "@smithy/middleware-serde": ^2.1.1
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/url-parser": ^2.1.1
+    "@smithy/util-middleware": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 685f74c76cba205bdb20ad7bda449b73e498ae2e9074a026d48b38c7b4456d8a0cfb4fdb48625b65f93f3a75e92eaf7951db28f8e9f44e50ce18fd59a7b325af
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-retry@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/middleware-retry@npm:2.1.1"
+  dependencies:
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/service-error-classification": ^2.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-middleware": ^2.1.1
+    "@smithy/util-retry": ^2.1.1
+    tslib: ^2.5.0
+    uuid: ^8.3.2
+  checksum: a4bc59d2ff8f65367aeb93391a2aafc7caf8031d8b2dfb32ee35748cdc46e06d5182c37bee90d7a107e890959bd40e6a7f4041bc1b0b36a99d14919b1cc78812
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/middleware-serde@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: ed77b80ac6b68640ee4bf8310bc4d9f5aa13de2741333f6f03a4983e897fa66e0de057d178e78d9ba095d5686d3e4531437c9dd2583366efe948bd75b2aa8581
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/middleware-stack@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 0d7c1051c96fcf19f7d5e96bc59484ce13df4e570c1da3eda74d23a7911b41eb61d6c378aad0aa21f7e9c72934148bdf39f9767c57abd4845aa4417a84e3f6e4
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@smithy/node-config-provider@npm:2.2.1"
+  dependencies:
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/shared-ini-file-loader": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 62ed3124d888a10cac633a250fbe12d6c5b8aa75ea691889abebce227cbaf155f3db00fa6beb453fbd6147e667e70819d043da1750980669451281a28eafd285
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@smithy/node-http-handler@npm:2.3.1"
+  dependencies:
+    "@smithy/abort-controller": ^2.1.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/querystring-builder": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: e6a514098f44cfc962318b15df79bb5e9de7fffe883fe073965879b2cf2436726709b5be14262871794104272e8506f793f8e77b8bf5b36398714a3a51512516
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/property-provider@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: e87d70c4efe07e830cfb2094b046af89175b87b13259fba37641aa7bfc2ab0c7bf2397797ac48b92e1feb11bf6129b82b350519172093efd7ac4d3a4a98bbe2f
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@smithy/protocol-http@npm:3.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: a5be1c5b5bff18c5a35c23870e1ffa38da33e56f93bdd8f26c615f4c0d2d3e1effffe441e756c0b0ba3aad2dd0845332f634702bf8455ed865a04eebfef1329b
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-builder@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/querystring-builder@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    "@smithy/util-uri-escape": ^2.1.1
+    tslib: ^2.5.0
+  checksum: b8623c7ef6d19fb21c41bfda29cce9c673ac501914085b39642ff5a72cf5742b19cd9de1a1851d13f2e1bbfc2e9522070b5ca32ed906aacf93f732a56e76098a
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/querystring-parser@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: bfac40793b0e42f4e25137db4e7d866debfa32557359cc41e02a23174a6fd8e0132f098cef5669a3ddf5211e477c9c97d4aa9039b35c7b4a29f2207236da236e
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/service-error-classification@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+  checksum: 59a5e3cb0fb42d70fc2d85814124abbff60e28cc9aa45d87fde3370e25943abaf4b6baf62cc40e496c3687e9fa9161156a055ad29a4f7ce8dd7d937bbf49f9a7
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@smithy/shared-ini-file-loader@npm:2.3.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 89b0dfb65faab917fcb4a6a8f34a85d668a759ccbfd6c4dc3d6311e59a8f1b78baab1d97402c333d2207da810cb00de9d5b4379f114bde82135f9aa0d0069cab
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/signature-v4@npm:2.1.1"
+  dependencies:
+    "@smithy/eventstream-codec": ^2.1.1
+    "@smithy/is-array-buffer": ^2.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-hex-encoding": ^2.1.1
+    "@smithy/util-middleware": ^2.1.1
+    "@smithy/util-uri-escape": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: fa3d4728b0bcf98e606a6e13a47f91efc6eb9edb6925ba48c3b9cecdf8170adf27e28a0684dabe385e8a7379d0743f52b19cd9a1a01884cd0f75c048c4324fd2
+  languageName: node
+  linkType: hard
+
+"@smithy/smithy-client@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@smithy/smithy-client@npm:2.3.1"
+  dependencies:
+    "@smithy/middleware-endpoint": ^2.4.1
+    "@smithy/middleware-stack": ^2.1.1
+    "@smithy/protocol-http": ^3.1.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-stream": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 9b13c361528b3120b1a1db17cd60521d04c72f664c2709be20934cea12756117441d2a33d0464ff3099be11ccb12946c62ece1126b9532eb8f6243a35d6fd171
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.9.1":
+  version: 2.9.1
+  resolution: "@smithy/types@npm:2.9.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 8570affb4abb5d0ead57293977fc915d44be481120defcabb87a3fb1c7b5d2501b117835eca357b5d54ea4bbee08032f9dc3d909ecbf0abb0cec2ca9678ae7bd
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/url-parser@npm:2.1.1"
+  dependencies:
+    "@smithy/querystring-parser": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 5c939f3ff9c53a0b7a0c5a1ac7641f229598d2bf9499e1abf4d33c1c1cd13bd5f7fcfffd00c366ca9f8092d28979a4a958b80f9bbc91e817e4d1940451e93489
+  languageName: node
+  linkType: hard
+
+"@smithy/util-base64@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-base64@npm:2.1.1"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 6dbb93b8745798d56476d37c99dc9f53fe5fc29329b8161fc9e5c55c5a3062916b3e5e4dd596541b248979eefa550d8da7fbb6ab254bf069cb4c920aea6c3590
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-body-length-browser@npm:2.1.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 6f7808a41b57a5ab1334f0d036ecec6809a959bcfe6a200f985f35e0c96e72f34fdcb6154873f795835d1d927098055e2dec31ebfb5e5382d1c4c612c80a37c0
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@smithy/util-body-length-node@npm:2.2.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 6bddc6fac7c9875ae7baaf6088d91192fbe4405bc5c1b69100d52aa1bfebabcc194f5f1b159d8f6f3ade3b54e416f185781970c30a97d4b0a7cec6d02fc490c4
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-buffer-from@npm:2.1.1"
+  dependencies:
+    "@smithy/is-array-buffer": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 8dc7f9afaa356696f14a80cd983a750cbad8eba7c46498ed74fb8ec0cb307f14df64fb10ceb30b2d4792395bb8b216c89155a93dee0f2b3e5cab94fef459a195
+  languageName: node
+  linkType: hard
+
+"@smithy/util-config-provider@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@smithy/util-config-provider@npm:2.2.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: f5b34bcf6ef944779f20d7639070e87a521e1a5620e5a91f2d2dbd764824985930a68b71b0b2bde12e1eaac947155789b73a8c09c1aa7ab923f08e42a4173ef4
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-defaults-mode-browser@npm:2.1.1"
+  dependencies:
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: 5d3b11be1768410e24ad9829dc70bed9b50419f85a8ca934c6296e21e278d87f665cfdb603241ef749f80d154a2c4be26cd29338daecc625d31b30af8bd9c139
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-node@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-defaults-mode-node@npm:2.1.1"
+  dependencies:
+    "@smithy/config-resolver": ^2.1.1
+    "@smithy/credential-provider-imds": ^2.2.1
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/property-provider": ^2.1.1
+    "@smithy/smithy-client": ^2.3.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 3d32e90ce9b6340f26f856c1fdd627b753faaa403813b7e6a51583bfaa6b7eab0f52fd6e067afb9f14e741c6fa31dfedfe22c7c73911b48f8f4fab0510992c32
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@smithy/util-endpoints@npm:1.1.1"
+  dependencies:
+    "@smithy/node-config-provider": ^2.2.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 40619bf739c1fc959486946cb49319f34c9c4c5c19f46cdefc7ff8e7331b84f6ad7a4aeb8a0268f6d77d266ff5ec9df8d2244094dd79ae469983e9c07e43766a
+  languageName: node
+  linkType: hard
+
+"@smithy/util-hex-encoding@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-hex-encoding@npm:2.1.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: eae5c94fd4d57dccbae5ad4d7684787b1e9b1df944cf9fcb497cbefaed6aec49c0a777cc1ea4d10fa7002b82f0b73b8830ae2efe98ed35a62dcf3c4f7d08a4cd
+  languageName: node
+  linkType: hard
+
+"@smithy/util-middleware@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-middleware@npm:2.1.1"
+  dependencies:
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 404bb944202df70ba0ff8bb6ea105ead0a6b365d5ef7bfafbfc919df228823563818f0ee36f0f1e20462200da2fb8c8961e20b237e4e1bd9f77c38dd701f39ab
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-retry@npm:2.1.1"
+  dependencies:
+    "@smithy/service-error-classification": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 1747c75f55a208f16104483cd76ec45200dedaa924868e84d4882b88f8b4a8d3a4422834359fd9bfba242e0e96a474349ac0a6f5d804fb15b15e8b639b6d2ad0
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-stream@npm:2.1.1"
+  dependencies:
+    "@smithy/fetch-http-handler": ^2.4.1
+    "@smithy/node-http-handler": ^2.3.1
+    "@smithy/types": ^2.9.1
+    "@smithy/util-base64": ^2.1.1
+    "@smithy/util-buffer-from": ^2.1.1
+    "@smithy/util-hex-encoding": ^2.1.1
+    "@smithy/util-utf8": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 3a060226b8a506e722d0d8c1c4b7a2989241f7946c8acc892a8a70d92d9952cc8619b14bf686c9c822115d99159c6c16534bad2d72ecc2809a56f865224e82a6
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-uri-escape@npm:2.1.1"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 822ed7390e28d5c7b8dab5e5c5a8de998e0778220137962a71b47b2d8900289d48a3a2c9945e68e1cac921d43f61660045e7fdffe8df9e63004575fcf2aa99b2
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-utf8@npm:2.1.1"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.1.1
+    tslib: ^2.5.0
+  checksum: 286ce5cba3f45a8abd3d6c28e40b3204dd64300340818d77e42c1cbb0c2f6ad0c42f0e47ffaf38d74d0895b0dfd1750c5b55222ab4d205a3b39da4325971d303
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/util-waiter@npm:2.1.1"
+  dependencies:
+    "@smithy/abort-controller": ^2.1.1
+    "@smithy/types": ^2.9.1
+    tslib: ^2.5.0
+  checksum: 52d9c82bb9684b6b11eeb2814fa1454514cb90aeeb87bfdf7c458613c13d18189712585486859c975824d08f2d1e3c817dd7e51c400531aaa479af8a06ea0bff
   languageName: node
   linkType: hard
 
@@ -2894,6 +4188,13 @@ __metadata:
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
   checksum: 3e25c80ef626c3a3487c73dbfc70ac322ec830666c9ad915d11b701142fab25ec1e63eff2c450c74347acfd2de854ccde865cd79ef4db1683f7c7b046ea43bb0
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "bowser@npm:2.11.0"
+  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
   languageName: node
   linkType: hard
 
@@ -5140,6 +6441,17 @@ __metadata:
   version: 2.2.0
   resolution: "fast-uri@npm:2.2.0"
   checksum: edac64d50628f21d562cdc19ea86f5af00902dbb09d2f96fff5974e5317157825e9aa163af9defd11a0818aac6ea2e9958597bed98dd041200a08a976809d08b
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:4.2.5":
+  version: 4.2.5
+  resolution: "fast-xml-parser@npm:4.2.5"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: d32b22005504eeb207249bf40dc82d0994b5bb9ca9dcc731d335a1f425e47fe085b3cace3cf9d32172dd1a5544193c49e8615ca95b4bf95a4a4920a226b06d80
   languageName: node
   linkType: hard
 
@@ -10201,6 +11513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
+  languageName: node
+  linkType: hard
+
 "sucrase@npm:^3.32.0":
   version: 3.34.0
   resolution: "sucrase@npm:3.34.0"
@@ -10579,14 +11898,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1":
+"tslib@npm:^1.11.1, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.1":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
@@ -11087,6 +12406,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds support for S3 storage solutions, like AWS S3, Backblaze, wasabi, and any other that have a S3-compatible API.
To enable the setting, head to your Dashboard > Settings > Uploads and fill the required information:

![image](https://github.com/chibisafe/chibisafe/assets/7425261/265bf578-5adb-4525-8d04-f42650b7aaa0)


A few things to consider when enabling S3 storage:
- Chunk uploads will be disabled.
- If the uploaded file is bigger than the max file size, the file will be deleted from the S3 bucket
- In order to generate thumbnails for uploaded media, chibisafe needs to download the file uploaded to the bucket once and take the necessary snapshots. This process will consume bandwidth from your S3 storage, so to avoid increased costs we limited the thumbnail generation to files smaller than 100MB
- The process to upload a file and put it in S3 storage is slightly different, so while the website behaves the same, ShareX uploads or third-party upload won't work anymore unless you use a plugin or dig into the API.
  - Before, a client could call `/api/upload` with the file and that would constitute an upload
  - Now a client needs to call `/api/upload`, which will return a signed url for the client to `PUT` the uploaded file into, and finally the client calls `/api/upload/process` to finish uploading and processing the file.

With the S3 storage setting disabled, chibisafe should behave exactly as it was before with no changes.