### PR TITLE
[Fix] Upload schema

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -259,7 +259,8 @@ export const getHtmlBuffer = async () => {
 		serviceName: SETTINGS.serviceName,
 		publicMode: SETTINGS.publicMode,
 		userAccounts: SETTINGS.userAccounts,
-		blockedExtensions: SETTINGS.blockedExtensions
+		blockedExtensions: SETTINGS.blockedExtensions,
+		useNetworkStorage: SETTINGS.useNetworkStorage
 	};
 
 	indexHTML = indexHTML.replaceAll(

--- a/packages/backend/src/routes/files/Upload.schema.ts
+++ b/packages/backend/src/routes/files/Upload.schema.ts
@@ -11,6 +11,23 @@ export default {
 			'chibi-uuid': { type: 'string' }
 		}
 	},
+	body: {
+		type: ['object', 'null'],
+		properties: {
+			size: {
+				type: 'number',
+				description: 'The size of the file.'
+			},
+			name: {
+				type: 'string',
+				description: 'The name of the file.'
+			},
+			contentType: {
+				type: 'string',
+				description: 'The content type of the file.'
+			}
+		}
+	},
 	response: {
 		200: {
 			type: 'object',


### PR DESCRIPTION
There was an issue when uploading with S3 on production build where the schema and the initial value for `useNetworkStorage` were missing.