### PR TITLE
Fix blocked extension management

### DIFF
--- a/packages/frontend/src/pages/dashboard/admin/settings.vue
+++ b/packages/frontend/src/pages/dashboard/admin/settings.vue
@@ -80,7 +80,7 @@
 
 									<div>
 										<Badge
-											v-for="(extension, idx) in String(setting.value).split(',')"
+											v-for="(extension, idx) of setting.value"
 											:key="idx"
 											class="mr-2"
 										>
@@ -157,22 +157,22 @@ const categorizedSettings = computed(() => {
 	return categorized;
 });
 
-const addExtension = (setting: any, extension: any) => {
+const addExtension = (setting: Setting, extension: any) => {
 	if (!extension.value) return;
-	const extensions = setting.value.split(',');
-	if (extensions.includes(extension.value)) return;
-	extensions.push(extension.value);
-	setting.value = extensions.join(',');
+	const extensions = setting.value as string[];
+	if (extensions.find(v => v == extension.value)) return;
+	extensions.push(extension.value.match(/^\./) ? extension.value : '.' + extension.value);
+	setting.value = extensions;
 	// @ts-expect-error erh something about the element not being an array
 	blockedExtensionsInput.value[0].value = '';
 };
 
-const removeExtension = (setting: any, extension: string) => {
-	const items = setting.value.split(',');
+const removeExtension = (setting: Setting, extension: string) => {
+	const items = setting.value as string[];
 	const index = items.indexOf(extension);
 	if (index > -1) {
 		items.splice(index, 1);
-		setting.value = items.join(',');
+		setting.value = items;
 	}
 };
 

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -157,5 +157,5 @@ export interface Setting {
 	name: string;
 	notice?: string;
 	type: string;
-	value: boolean | number | string;
+	value: boolean | number | string | string[];
 }


### PR DESCRIPTION
This PR aims to fix the a mismatch between the front and backend. The frontend assumes that the blocked extension setting has a value that is a string, but in reality it is an array. This results in some errors and renders the function to remove a blocked extension unusable, as shown in #563 .

I had to work around some type errors by casting the setting's value as string[], but this is clearly shown in the code and I have modified the type itself to at least reference the fact that setting.value could be an array of strings.

The final change involves adding an extension. The input tip shows that you shouldn't include "." in front of the extension that the admin wants to add to the blocklist, but there is no code to add that "." before adding it to the array which is required for the uploader to correctly block uploads that match the list.