### PR TITLE
feat: file/uuid path which returns file with original filename

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,9 +12,9 @@ import { cleanup } from 'unzipit';
 import Routes from './structures/routes.js';
 import { SETTINGS, loadSettings } from './structures/settings.js';
 import Docs from './utils/Docs.js';
+import { getOriginalFile } from './utils/GetOriginalFile.js';
 import { log } from './utils/Logger.js';
 import Requirements from './utils/Requirements.js';
-import { jumpstartStatistics } from './utils/StatsGenerator.js';
 import { startUpdateCheckSchedule } from './utils/UpdateCheck.js';
 import { createAdminUserIfNotExists, VERSION } from './utils/Util.js';
 import { fileWatcher, getFileWatcher } from './utils/Watcher.js';
@@ -252,17 +252,12 @@ const start = async () => {
 		await server.register(fstatic, {
 			root: fileURLToPath(new URL('../../../uploads', import.meta.url))
 		});
+
+		server.get('/file/:uuid', getOriginalFile);
 	}
 
 	// Start the server
 	await server.listen({ port: Number(SETTINGS.port), host: SETTINGS.host as string });
-
-	// Uncomment this to generate a swagger.yml file with the OpenAPI documentation
-	// const yaml = server.swagger({ yaml: true });
-	// await jetpack.writeAsync('./swagger.yml', yaml);
-
-	// Jumpstart statistics scheduler
-	await jumpstartStatistics();
 
 	if (!SETTINGS.disableUpdateCheck) {
 		await startUpdateCheckSchedule();

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -15,6 +15,7 @@ import Docs from './utils/Docs.js';
 import { getOriginalFile } from './utils/GetOriginalFile.js';
 import { log } from './utils/Logger.js';
 import Requirements from './utils/Requirements.js';
+import { jumpstartStatistics } from './utils/StatsGenerator.js';
 import { startUpdateCheckSchedule } from './utils/UpdateCheck.js';
 import { createAdminUserIfNotExists, VERSION } from './utils/Util.js';
 import { fileWatcher, getFileWatcher } from './utils/Watcher.js';
@@ -258,6 +259,13 @@ const start = async () => {
 
 	// Start the server
 	await server.listen({ port: Number(SETTINGS.port), host: SETTINGS.host as string });
+
+	// Uncomment this to generate a swagger.yml file with the OpenAPI documentation
+	// const yaml = server.swagger({ yaml: true });
+	// await jetpack.writeAsync('./swagger.yml', yaml);
+
+	// Jumpstart statistics scheduler
+	await jumpstartStatistics();
 
 	if (!SETTINGS.disableUpdateCheck) {
 		await startUpdateCheckSchedule();

--- a/packages/backend/src/routes/admin/files/GetFile.ts
+++ b/packages/backend/src/routes/admin/files/GetFile.ts
@@ -88,7 +88,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 
 	const extendedFile = {
 		...file,
-		...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3, isWatched: file.isWatched })
+		...constructFilePublicLink({
+			req,
+			uuid: file.uuid,
+			fileName: file.name,
+			isS3: file.isS3,
+			isWatched: file.isWatched
+		})
 	};
 
 	return res.send({

--- a/packages/backend/src/routes/admin/files/GetFiles.ts
+++ b/packages/backend/src/routes/admin/files/GetFiles.ts
@@ -116,6 +116,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			...file,
 			...constructFilePublicLink({
 				req,
+				uuid: file.uuid,
 				fileName: quarantine ? file.quarantineFile.name : file.name,
 				quarantine,
 				isS3: file.isS3,

--- a/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
+++ b/packages/backend/src/routes/admin/ip/GetFilesFromIP.ts
@@ -65,7 +65,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3, isWatched: file.isWatched })
+			...constructFilePublicLink({
+				req,
+				uuid: file.uuid,
+				fileName: file.name,
+				isS3: file.isS3,
+				isWatched: file.isWatched
+			})
 		});
 	}
 

--- a/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
+++ b/packages/backend/src/routes/admin/users/GetUserWithFiles.ts
@@ -115,7 +115,13 @@ export const run = async (req: FastifyRequest, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3, isWatched: file.isWatched })
+			...constructFilePublicLink({
+				req,
+				uuid: file.uuid,
+				fileName: file.name,
+				isS3: file.isS3,
+				isWatched: file.isWatched
+			})
 		});
 	}
 

--- a/packages/backend/src/routes/album/GetAlbum.ts
+++ b/packages/backend/src/routes/album/GetAlbum.ts
@@ -85,7 +85,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		const modifiedFile = file as unknown as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLink({ req, fileName: modifiedFile.name, isS3: file.isS3, isWatched: file.isWatched })
+			...constructFilePublicLink({
+				req,
+				uuid: modifiedFile.uuid,
+				fileName: modifiedFile.name,
+				isS3: file.isS3,
+				isWatched: file.isWatched
+			})
 		});
 	}
 

--- a/packages/backend/src/routes/files/GetFile.ts
+++ b/packages/backend/src/routes/files/GetFile.ts
@@ -73,7 +73,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	let parsedFile: ExtendedFile = file;
 	parsedFile = {
 		...file,
-		...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3, isWatched: file.isWatched })
+		...constructFilePublicLink({
+			req,
+			uuid: file.uuid,
+			fileName: file.name,
+			isS3: file.isS3,
+			isWatched: file.isWatched
+		})
 	};
 
 	return res.send({

--- a/packages/backend/src/routes/files/GetFiles.ts
+++ b/packages/backend/src/routes/files/GetFiles.ts
@@ -73,7 +73,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3, isWatched: file.isWatched })
+			...constructFilePublicLink({
+				req,
+				uuid: file.uuid,
+				fileName: file.name,
+				isS3: file.isS3,
+				isWatched: file.isWatched
+			})
 		});
 	}
 

--- a/packages/backend/src/routes/files/Search.ts
+++ b/packages/backend/src/routes/files/Search.ts
@@ -120,7 +120,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	for (const file of files) {
 		readyFiles.push({
 			...file,
-			...constructFilePublicLink({ req, fileName: file.name, isS3: file.isS3, isWatched: file.isWatched })
+			...constructFilePublicLink({
+				req,
+				uuid: file.uuid,
+				fileName: file.name,
+				isS3: file.isS3,
+				isWatched: file.isWatched
+			})
 		});
 	}
 

--- a/packages/backend/src/routes/tag/GetTag.ts
+++ b/packages/backend/src/routes/tag/GetTag.ts
@@ -92,7 +92,13 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 		const modifiedFile = file as unknown as File;
 		files.push({
 			...modifiedFile,
-			...constructFilePublicLink({ req, fileName: modifiedFile.name, isS3: modifiedFile.isS3, isWatched: true })
+			...constructFilePublicLink({
+				req,
+				uuid: modifiedFile.uuid,
+				fileName: modifiedFile.name,
+				isS3: modifiedFile.isS3,
+				isWatched: true
+			})
 		});
 	}
 

--- a/packages/backend/src/structures/schemas/FileAsUser.ts
+++ b/packages/backend/src/structures/schemas/FileAsUser.ts
@@ -11,6 +11,7 @@ export const fileAsUserSchema = z
 		size: z.coerce.number().describe('The size of the file in bytes.'),
 		type: z.string().describe('The type of the file.'),
 		url: z.string().describe('The URL of the file.'),
+		uuidUrl: z.string().describe('The uuid URL of the file.'),
 		thumb: z.string().describe('The URL of the thumbnail of the file.'),
 		thumbSquare: z.string().describe('The URL of the square thumbnail of the file.'),
 		preview: z.string().describe('The URL of the preview of the file.'),

--- a/packages/backend/src/utils/File.ts
+++ b/packages/backend/src/utils/File.ts
@@ -241,6 +241,7 @@ export const createZip = (files: string[], albumUuid: string) => {
 
 export const constructFilePublicLink = ({
 	req,
+	uuid,
 	fileName,
 	quarantine = false,
 	isS3 = false,
@@ -251,12 +252,15 @@ export const constructFilePublicLink = ({
 	isWatched?: boolean;
 	quarantine?: boolean;
 	req: FastifyRequest;
+	uuid?: string;
 }) => {
 	const host = SETTINGS.serveUploadsFrom ? SETTINGS.serveUploadsFrom : getHost(req);
 	const data = {
 		url: isS3
 			? `${SETTINGS.S3PublicUrl || SETTINGS.S3Endpoint}${quarantine ? '/quarantine' : ''}/${fileName}`
 			: `${host}${quarantine ? '/quarantine' : ''}${isWatched ? '/live' : ''}/${fileName}`,
+		// uuid url that accounts for s3
+		uuidUrl: uuid ? `${isS3 ? SETTINGS.S3PublicUrl || SETTINGS.S3Endpoint : host}/file/${uuid}` : '',
 		thumb: '',
 		thumbSquare: '',
 		preview: ''

--- a/packages/backend/src/utils/GetOriginalFile.ts
+++ b/packages/backend/src/utils/GetOriginalFile.ts
@@ -1,0 +1,19 @@
+import { URL, fileURLToPath } from 'node:url';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import prisma from '@/structures/database.js';
+
+export const getOriginalFile = async (req: FastifyRequest, res: FastifyReply) => {
+	const { uuid } = req.params as { uuid: string };
+	const file = await prisma.files.findUnique({ where: { uuid } });
+
+	if (!file) {
+		void res.notFound();
+		return;
+	}
+
+	const { original, name } = file;
+
+	const root = fileURLToPath(new URL('../../../../uploads', import.meta.url));
+
+	return res.header('Content-Disposition', `inline; filename="${original}"`).sendFile(name, root);
+};

--- a/packages/frontend/src/components/dialogs/FileInformationDialog.vue
+++ b/packages/frontend/src/components/dialogs/FileInformationDialog.vue
@@ -159,6 +159,14 @@
 								readOnly
 							/>
 							<InputWithOverlappingLabel
+								:value="file.uuidUrl"
+								class="mt-4"
+								label="Link with original filename"
+								type="link"
+								:href="file.uuidUrl"
+								readOnly
+							/>
+							<InputWithOverlappingLabel
 								:value="String(formatBytes(file.size))"
 								class="mt-4"
 								label="Size"

--- a/packages/frontend/src/components/upload/ChibiUploader.vue
+++ b/packages/frontend/src/components/upload/ChibiUploader.vue
@@ -246,7 +246,8 @@ const uploadFile = async ({
 				bytesSent: 0,
 				bytesTotal: file.size,
 				progress: 0,
-				url: ''
+				url: '',
+				uuidUrl: ''
 			});
 		},
 		onError: (uuid: string, error: any) => {

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -42,6 +42,7 @@ export interface File {
 	type: string;
 	url: string | undefined;
 	uuid: string;
+	uuidUrl: string;
 }
 
 export interface FileWithAdditionalData extends File {


### PR DESCRIPTION
Exposes a route at .../file/{uuid} that returns the file with the original filename. Includes a link field in the file details modal.

https://github.com/chibisafe/chibisafe/assets/68029599/f64cde80-f29c-46ec-aaeb-77a5ac1dd16a

