### PR TITLE
feat: improve onboarding by making settings simpler

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,8 +15,6 @@ services:
       - ./database:/app/database:rw
       - ./uploads:/app/uploads:rw
       - ./logs:/app/logs:rw
-    environment:
-      - SERVE_UPLOADS_FROM=http://localhost:24424
     expose:
       - 8000
     restart: unless-stopped

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -15,8 +15,6 @@ services:
       - ./database:/app/database:rw
       - ./uploads:/app/uploads:rw
       - ./logs:/app/logs:rw
-    environment:
-      - SERVE_UPLOADS_FROM=http://localhost:24424
     expose:
       - 8000
     restart: unless-stopped

--- a/docker/DockerfileServer
+++ b/docker/DockerfileServer
@@ -16,7 +16,6 @@ ENV NODE_ENV=production
 EXPOSE 8000
 ENV HOSTNAME 0.0.0.0
 ENV HOST 0.0.0.0
-ENV SERVE_UPLOADS_FROM=http://localhost:24424
 ENV PORT 8000
 
 CMD ["yarn", "workspace", "@chibisafe/backend", "start"]

--- a/packages/backend/src/routes/GetSettings.ts
+++ b/packages/backend/src/routes/GetSettings.ts
@@ -25,7 +25,8 @@ export const schema = {
 			useMinimalHomepage: z
 				.boolean()
 				.optional()
-				.describe('Whether or not to use a minimal version of the homepage.')
+				.describe('Whether or not to use a minimal version of the homepage.'),
+			serveUploadsFrom: z.string().optional().describe('The URL to serve uploads from.')
 		})
 	}
 };
@@ -50,6 +51,7 @@ export const run = (_: RequestWithUser, res: FastifyReply) => {
 		userAccounts: SETTINGS.userAccounts,
 		blockedExtensions: SETTINGS.blockedExtensions,
 		useNetworkStorage: SETTINGS.useNetworkStorage,
-		useMinimalHomepage: SETTINGS.useMinimalHomepage
+		useMinimalHomepage: SETTINGS.useMinimalHomepage,
+		serveUploadsFrom: SETTINGS.serveUploadsFrom
 	});
 };

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -38,7 +38,7 @@ export const loadSettings = async (force = false) => {
 
 		// These settings should be set from the database
 		SETTINGS.serviceName = settingsTable.serviceName;
-		SETTINGS.serveUploadsFrom = settingsTable.serveUploadsFrom || (process.env.SERVE_UPLOADS_FROM ?? '');
+		SETTINGS.serveUploadsFrom = settingsTable.serveUploadsFrom || '';
 		SETTINGS.rateLimitWindow = settingsTable.rateLimitWindow;
 		SETTINGS.rateLimitMax = settingsTable.rateLimitMax;
 		SETTINGS.secret = settingsTable.secret;

--- a/packages/next/.env.development
+++ b/packages/next/.env.development
@@ -1,2 +1,1 @@
 BASE_API_URL=http://localhost:8000
-SERVE_UPLOADS_FROM=http://localhost:8000

--- a/packages/next/.env.production.example
+++ b/packages/next/.env.production.example
@@ -1,2 +1,1 @@
 BASE_API_URL=http://localhost:8000
-SERVE_UPLOADS_FROM=http://localhost:8000

--- a/packages/next/src/app/(home)/guides/(content)/running-manually/page.mdx
+++ b/packages/next/src/app/(home)/guides/(content)/running-manually/page.mdx
@@ -45,11 +45,6 @@ With chibisafe now built you need to run both the backend and the frontend proce
 echo "BASE_API_URL=http://127.0.0.1:8000" >> ./packages/next/.env
 ```
 
-After that's done, run the following command replacing `https://chibi.domain` with your domain, for example `https://chibisafe.app`
-```bash
-echo "SERVE_UPLOADS_FROM=https://chibi.domain" >> ./packages/backend/.env
-```
-
 You can start both processes by running the following 2 commands in either separate terminals or tmux sessions.
 ```bash
 yarn start:backend
@@ -79,9 +74,8 @@ If you rather use PM2 what you can do is create a file called `chibisafe.json` i
       "script": "yarn",
       "args": ["workspace", "@chibisafe/backend", "start"],
       "env": {
-            "SERVE_UPLOADS_FROM": "https://chibi.domain",
-            "NODE_ENV": "production"
-        }
+        "NODE_ENV": "production"
+      }
     }
   ]
 }

--- a/packages/next/src/app/(home)/guides/(content)/running-with-docker/page.mdx
+++ b/packages/next/src/app/(home)/guides/(content)/running-with-docker/page.mdx
@@ -32,8 +32,6 @@ services:
       - ./database:/app/database:rw
       - ./uploads:/app/uploads:rw
       - ./logs:/app/logs:rw
-    environment:
-      - SERVE_UPLOADS_FROM=http://localhost:24424
     expose:
       - 8000
     restart: unless-stopped
@@ -49,10 +47,6 @@ services:
       - BASE_URL=":80"
     restart: unless-stopped
 ```
-
-<Callout type="warning">
-  Please note that you need to change `SERVE_UPLOADS_FROM` to reflect your full domain where you will be serving this chibisafe instance from. It is also worth mentioning that you can either change it in your docker-compose.yml file as shown above or once you have chibisafe running from the admin dashboard.
-</Callout>
 
 Now that your `docker-compose.yml` file is set up it's now time to create the `Caddyfile` to finish the configuration process:
 

--- a/packages/next/src/app/(home)/guides/(content)/running-with-docker/page.mdx
+++ b/packages/next/src/app/(home)/guides/(content)/running-with-docker/page.mdx
@@ -47,6 +47,10 @@ services:
       - BASE_URL=":80"
     restart: unless-stopped
 ```
+<Callout type="danger">
+  Even if you use NGINX Proxy Manager, or Caddy in your host system, it is still necessary to hhave Caddy inside the docker compose file. Do not change these options unless you know what you are doing, otherwise you'll break the routing.
+</Callout>
+
 
 Now that your `docker-compose.yml` file is set up it's now time to create the `Caddyfile` to finish the configuration process:
 
@@ -77,9 +81,6 @@ Now that your `docker-compose.yml` file is set up it's now time to create the `C
 	}
 }
 ```
-<Callout type="warning">
-  We've been getting many questions if it's okay to remove the Caddy service from the docker compose file if you are already running Caddy yourself and the short answer is no. Caddy inside the containers runs as a proxy pass between the 2 services to expose just 1 port for you to actually proxy pass outside of Docker, so it's best if you leave it there.
-</Callout>
 
 ### Running chibisafe
 Now that you have every piece needed, you can launch chibisafe by running the following command:

--- a/packages/next/src/app/layout.tsx
+++ b/packages/next/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { UserProvider } from '@/components/providers/UserProvider';
 import { Providers } from './providers';
 import { GlobalBackground } from '@/components/GlobalBackground';
 import request from '@/lib/request';
+import { GlobalAdminNotice } from '@/components/GlobalAdminNotice';
 
 export const viewport: Viewport = {
 	width: 'device-width',
@@ -103,6 +104,7 @@ export default function RootLayout({ children }: PropsWithChildren<{}>) {
 				)}
 			>
 				<Providers>
+					<GlobalAdminNotice />
 					{children}
 					<GlobalBackground />
 					<Toaster position="bottom-center" />

--- a/packages/next/src/components/GlobalAdminNotice.tsx
+++ b/packages/next/src/components/GlobalAdminNotice.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { currentUserAtom } from '@/lib/atoms/currentUser';
+import { settingsAtom } from '@/lib/atoms/settings';
+import { useAtomValue } from 'jotai';
+import Link from 'next/link';
+
+export const GlobalAdminNotice = () => {
+	const settings = useAtomValue(settingsAtom);
+	const currentUser = useAtomValue(currentUserAtom);
+
+	if (settings?.serveUploadsFrom || !currentUser?.roles.some(role => role.name === 'admin')) {
+		return null;
+	}
+
+	return (
+		<div className="bg-yellow-700 text-white p-2 text-center text-sm">
+			Files and thumbnails will be broken until you add your full domain in{' '}
+			<Link href="/dashboard/settings" className="underline">
+				Settings {'>'} Service {'>'} Serve uploads from
+			</Link>
+		</div>
+	);
+};

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -103,8 +103,14 @@ export interface Settings {
 	chunkSize: number;
 	logoURL: string;
 	maxSize: number;
+	metaDescription: string;
+	metaDomain: string;
+	metaKeywords: string;
+	metaTwitterHandle: string;
 	publicMode: boolean;
+	serveUploadsFrom: string;
 	serviceName: string;
+	useMinimalHomepage: boolean;
 	useNetworkStorage: boolean;
 	userAccounts: boolean;
 }


### PR DESCRIPTION
- Removed `SERVE_UPLOADS_FROM` env variable
- Added a banner for admins that shows up if `Serve uploads from` setting is not set in the dashboard, with a link to fix it.