### PR TITLE
Update Caddyfile to trust local proxies

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,10 @@
+{
+	servers {
+		trusted_proxies static private_ranges
+		client_ip_headers X-Forwarded-For X-Real-IP
+	}
+}
+
 {$BASE_URL} {
 	route {
 		file_server * {


### PR DESCRIPTION
Basically what the title says. The guide recommends folks to use their own proxy in front of the one in use to unify the frontend and the api, hence we should also make sure that Caddy is set up to allow for that kind of a structure by default.