### PR TITLE
Add basic health check endpoint to API

### DIFF
--- a/packages/backend/src/routes/health/HealthCheck.ts
+++ b/packages/backend/src/routes/health/HealthCheck.ts
@@ -1,0 +1,24 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+
+export const schema = {
+	summary: 'Get application health status',
+	description: 'Get the current health status of the application',
+	tags: ['Server'],
+	response: {
+		200: z.object({
+			status: z.string().describe('The current health status of the application.')
+		})
+	}
+};
+
+export const options = {
+	url: '/health',
+	method: 'get'
+};
+
+export const run = (_: FastifyRequest, res: FastifyReply) => {
+	return res.send({
+		status: "Alive"
+	});
+};

--- a/packages/backend/src/routes/health/HealthCheck.ts
+++ b/packages/backend/src/routes/health/HealthCheck.ts
@@ -19,6 +19,6 @@ export const options = {
 
 export const run = (_: FastifyRequest, res: FastifyReply) => {
 	return res.send({
-		status: "Alive"
+		status: "yes"
 	});
 };


### PR DESCRIPTION
Another short and sweet PR.

Add an endpoint for health checking. This can be used in conjunction with other apps to send notifications in case something goes wrong with the API server. We also have the option of adding other checks, such as db access, in the near future.