### PR TITLE
Add option to specify admin account password using env var

### DIFF
--- a/packages/backend/src/utils/Util.ts
+++ b/packages/backend/src/utils/Util.ts
@@ -69,7 +69,7 @@ export const createAdminUserIfNotExists = async () => {
 	});
 
 	if (!ownerUser) {
-		const hash = await bcrypt.hash('admin', 10);
+		const hash = await bcrypt.hash(process.env.ADMIN_SECRET ?? 'admin', 10);
 		await prisma.users.create({
 			data: {
 				uuid: uuidv4(),


### PR DESCRIPTION
Closes #586 . Not sure if there are ways to improve this implementation, maybe some input sanitation in the future?
Tested on my machine and works.

PS: Do note that the env var has to be applied to the API server and not the front end.