### PR TITLE
feat: enable carousel for masonry

### DIFF
--- a/packages/next/src/components/FileThumbnail.tsx
+++ b/packages/next/src/components/FileThumbnail.tsx
@@ -3,7 +3,7 @@
 import { selectedFileAtom, isDialogOpenAtom } from '@/lib/atoms/fileInformationDialog';
 import { isFileImage, isFileVideo, isFileAudio, isFilePDF } from '@/lib/file';
 import { cn } from '@/lib/utils';
-import type { File, FilePropsType } from '@/types';
+import type { File, FilePropsType, FileWithIndex } from '@/types';
 import { useSetAtom } from 'jotai';
 import { FileWarning, Video, FileAudio, FileText, FileIcon } from 'lucide-react';
 import { useState, type PropsWithChildren } from 'react';
@@ -13,7 +13,11 @@ const ComponentType = ({
 	isTableView,
 	file,
 	type
-}: PropsWithChildren<{ readonly file?: File; readonly isTableView?: boolean; readonly type: FilePropsType }>) => {
+}: PropsWithChildren<{
+	readonly file?: FileWithIndex;
+	readonly isTableView?: boolean;
+	readonly type: FilePropsType;
+}>) => {
 	const setModalOpen = useSetAtom(isDialogOpenAtom);
 	const setSelectedFile = useSetAtom(selectedFileAtom);
 
@@ -46,7 +50,7 @@ export const FileThumbnail = ({
 	isTableView = false,
 	type
 }: {
-	readonly file: File;
+	readonly file: FileWithIndex;
 	readonly hoveredFiles?: string[];
 	readonly isTableView?: boolean;
 	readonly type: FilePropsType;

--- a/packages/next/src/components/Masonry.tsx
+++ b/packages/next/src/components/Masonry.tsx
@@ -2,10 +2,10 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import type { File, FilePropsType } from '@/types';
+import type { File, FilePropsType, FileWithIndex } from '@/types';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useSearchParams } from 'next/navigation';
-import { isDialogOpenAtom, selectedFileAtom, currentTypeAtom } from '@/lib/atoms/fileInformationDialog';
+import { isDialogOpenAtom, selectedFileAtom, currentTypeAtom, allFilesAtom } from '@/lib/atoms/fileInformationDialog';
 import { isFileVideo } from '@/lib/file';
 import { cn } from '@/lib/utils';
 import { Masonry as Plock } from '@/components/ui/plock';
@@ -41,13 +41,21 @@ export function Masonry({
 
 	const setModalOpen = useSetAtom(isDialogOpenAtom);
 	const setSelectedFile = useSetAtom(selectedFileAtom);
+	const setAllFilesAtom = useSetAtom(allFilesAtom);
 	const setCurrentType = useSetAtom(currentTypeAtom);
 	const [hoveredFiles, setHoveredFiles] = useState<string[]>([]);
 	const showMasonry = useAtomValue(isMasonryViewAtom);
+	const [filesToUse, setFilesToUse] = useState<FileWithIndex[]>(
+		(files?.length ? files : isUploads || isAlbumUploads ? data?.files ?? [] : []).map((file, index) => ({
+			...file,
+			index
+		}))
+	);
 
 	useEffect(() => {
 		setCurrentType(type);
-	}, [setCurrentType, type]);
+		setAllFilesAtom(filesToUse);
+	}, [filesToUse, setAllFilesAtom, setCurrentType, type]);
 
 	const addToHoveredList = useCallback(
 		(file: File) => {
@@ -71,7 +79,7 @@ export function Masonry({
 		<>
 			{showMasonry ? (
 				<Plock
-					items={files?.length ? files : isUploads || isAlbumUploads ? data?.files ?? [] : []}
+					items={filesToUse}
 					config={{
 						columns: [2, 2, 3, 4],
 						gap: [10, 14, 14, 14],

--- a/packages/next/src/lib/atoms/fileInformationDialog.ts
+++ b/packages/next/src/lib/atoms/fileInformationDialog.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai';
-import type { FilePropsType, FileWithAdditionalData } from '@/types';
+import type { FilePropsType, FileWithIndex } from '@/types';
 
 export const isDialogOpenAtom = atom(false);
-export const selectedFileAtom = atom<FileWithAdditionalData | null>(null);
+export const selectedFileAtom = atom<FileWithIndex | null>(null);
 export const currentTypeAtom = atom<FilePropsType | null>(null);
+export const allFilesAtom = atom<FileWithIndex[]>([]);

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -97,6 +97,10 @@ export interface FileWithAdditionalData extends File {
 	};
 }
 
+export interface FileWithIndex extends FileWithAdditionalData {
+	index: number;
+}
+
 export interface Settings {
 	backgroundImageURL: string;
 	blockedExtensions: string[];


### PR DESCRIPTION
- Enables switching previous/next file with arrow keys
- Enables pressing the new floating arrow icons to switch previous/next file