### PR TITLE
Update running-with-docker.mdx to clarify directory structure

### DIFF
--- a/packages/next/src/content/guides/running-with-docker.mdx
+++ b/packages/next/src/content/guides/running-with-docker.mdx
@@ -19,9 +19,14 @@ This lets you get up and running with only a few commands and it comes in 2 diff
 ### Configuring
 In order to use our images you need to create somewhere in your system just 2 files, `docker-compose.yml` and `Caddyfile`. The way our docker compose file is structured it will create 3 services which are the chibisafe backend, the chibisafe frontend, and a very minimal caddy instance to merge those 2 services into 1 resulting port.
 
+This is what your directory should look like
+<pre>
+└── chibisafe
+    ├── docker-compose.yml
+    └── Caddyfile
+</pre>
 ```yml
-version: "3.7"
-
+#  chibisafe/docker-compose.yml
 services:
   chibisafe:
     image: chibisafe/chibisafe:latest
@@ -59,7 +64,8 @@ services:
 
 Now that your `docker-compose.yml` file is set up it's now time to create the `Caddyfile` to finish the configuration process:
 
-```yml
+```Caddyfile
+#  chibisafe/Caddyfile
 {$BASE_URL} {
 	route {
 		file_server * {
@@ -106,9 +112,13 @@ After the chibisafe images are pulled and the setup process finishes, you will b
 In order to attach a domain name to an application running with an exposed port like chibisafe you need to set up a reverse proxy in your system. The 2 most common solutions for this are [Caddy](https://caddyserver.com/) and [NGINX](https://www.nginx.com/), and we prefer Caddy since it's simpler to use and understand. For that reason we'll only be providing a Caddyfile configuration snippet to get you up and running, so if you have further questions you can head to our [Discord support server](https://discord.gg/5g6vgwn) and ask or open a GitHub issue and we'll try to get back to you as soon as possible.
 
 #### Caddy
+<Callout type="warning">
+  This section explains configuration options for Caddy installs on your host system. This is separate from the Caddy install used within the Chibisafe stack.
+</Callout>
 
 Once you have Caddy installed locally you can add this to your Caddyfile in order reverse proxy the exposed port from chibisafe:
-```yml
+```Caddyfile
+#  /etc/caddy/Caddyfile
 your-chibisafe-domain.com {
 	tls internal
 	reverse_proxy localhost:24424
@@ -116,7 +126,8 @@ your-chibisafe-domain.com {
 ```
 
 If you are a CloudFlare user and want your instance to be proxied by them, you should instead use the one below since it adds the necessary headers to pass the visitor's IP to the chibisafe instance.
-```yml
+```Caddyfile
+#  /etc/caddy/Caddyfile
 your-chibisafe-domain.com {
 	tls internal
 	reverse_proxy localhost:24424 {


### PR DESCRIPTION
Slight fixes and a bit more clarification on directory structures. Hopefully prevents confusion between Caddy within chibisafe vs Caddy on the host machine