### PR TITLE
Update running-with-docker-compose-and-traefik.mdx

### DIFF
--- a/packages/next/src/content/guides/running-with-docker-compose-and-traefik.mdx
+++ b/packages/next/src/content/guides/running-with-docker-compose-and-traefik.mdx
@@ -49,8 +49,8 @@ services:
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./uploads:/app/uploads:ro
-    expose:
-      - 80
+    ports:
+      - 24424:80
     environment:
       - BASE_URL=":80"
     restart: unless-stopped


### PR DESCRIPTION
This change will allow you to upload images locally using sharex by setting the domain as http://LOCAL_SERVER_IP:24424/api/upload, while keeping the rest of the functionality the same