### PR TITLE
Fix typo in the 'Manage albums' modal

### DIFF
--- a/packages/next/src/components/dialogs/bulk-actions/BulkAlbumActions.tsx
+++ b/packages/next/src/components/dialogs/bulk-actions/BulkAlbumActions.tsx
@@ -279,7 +279,7 @@ export const BulkAlbumActions = ({
 				<DialogHeader>
 					<DialogTitle>Manage albums</DialogTitle>
 					<DialogDescription>
-						Use the dropdown below to manage the albums from all thhe selected files.
+						Use the dropdown below to manage the albums from all the selected files.
 					</DialogDescription>
 				</DialogHeader>
 				<div className="grid gap-4">


### PR DESCRIPTION
Fixes the following typo:
![image](https://github.com/user-attachments/assets/cccd7a4f-7c42-4ecf-a31e-7a08dea4b4f4)
