### PR TITLE
docs(guides): add a traefik + nginx guide

### DIFF
--- a/packages/next/src/content/guides/running-with-docker-traefik-and-nginx.mdx
+++ b/packages/next/src/content/guides/running-with-docker-traefik-and-nginx.mdx
@@ -1,0 +1,188 @@
+---
+title: Running chibisafe with Docker, Traefik and NGINX
+summary: An overview guide on how to run chibisafe with Traefik and NGINX
+---
+
+This guide assumes you have a running instance of Traefik. If you don't, please refer to the [official Traefik documentation](https://doc.traefik.io/traefik) for installation instructions.
+
+## Prerequisites
+
+You need to have Docker and Docker Compose installed on your system before proceeding any further, as this guide already assumes they are.
+
+## Directory Structure
+
+Ensure you have the following directory structure:
+
+```
+/path/to/chibisafe
+└── docker-compose.yml
+/path/to/traefik
+└── dynamic.yml # This is your Traefik configuration file.
+```
+
+## /path/to/chibisafe/docker-compose.yml
+
+```yml
+services:
+  chibisafe:
+    restart: unless-stopped
+    container_name: chibisafe
+    image: chibisafe/chibisafe:latest
+    hostname: chibisafe
+    environment:
+      - BASE_API_URL=http://chibisafe-server:8000
+    networks:
+      - traefik
+    labels:
+      traefik.enable: true
+
+			# HTTP Router
+      traefik.http.routers.chibisafe-http.entrypoints: web
+      traefik.http.routers.chibisafe-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file,cloudflarewarp@docker # Optional
+      traefik.http.routers.chibisafe-http.rule: Host(`your-domain-name.com`) && !PathPrefix(`/api`) && !PathPrefix(`/docs`)
+      traefik.http.routers.chibisafe-http.service: chibisafe
+
+			# HTTPS Router (Secure)
+      traefik.http.routers.chibisafe.entrypoints: websecure
+      traefik.http.routers.chibisafe.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file,cloudflarewarp@docker # Optional
+      traefik.http.routers.chibisafe.rule: Host(`your-domain-name.com`) && !PathPrefix(`/api`) && !PathPrefix(`/docs`)
+      traefik.http.routers.chibisafe.service: chibisafe
+      traefik.http.routers.chibisafe.tls.certresolver: cfdns # Alternatively, you can use letsencrypt
+      traefik.http.routers.chibisafe.tls.options: securetls@file
+
+      traefik.http.services.chibisafe.loadbalancer.server.port: 8001
+
+  chibisafe-server:
+    restart: unless-stopped
+    container_name: chibisafe-server
+    image: chibisafe/chibisafe-server:latest
+    hostname: chibisafe-server
+    networks:
+      - traefik
+    labels:
+      traefik.enable: true
+
+			# HTTP Router
+			traefik.http.routers.chibisafe-server-http.entrypoints: web
+      traefik.http.routers.chibisafe-server-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file,cloudflarewarp@docker # Optional
+      traefik.http.routers.chibisafe-server-http.rule: Host(`your-domain-name.com`) && (PathPrefix(`/api`) || PathPrefix(`/docs`))
+      traefik.http.routers.chibisafe-server-http.service: chibisafe-server
+
+			# HTTPS Router (Secure)
+      traefik.http.routers.chibisafe-server.entrypoints: websecure
+      traefik.http.routers.chibisafe-server.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file,cloudflarewarp@docker
+      traefik.http.routers.chibisafe-server.rule: Host(`your-domain-name.com`) && (PathPrefix(`/api`) || PathPrefix(`/docs`)) # Optional
+      traefik.http.routers.chibisafe-server.service: chibisafe-server
+      traefik.http.routers.chibisafe-server.tls.certresolver: cfdns # Alternatively, you can use letsencrypt
+      traefik.http.routers.chibisafe-server.tls.options: securetls@file
+
+      traefik.http.services.chibisafe-server.loadbalancer.server.port: 8000
+    volumes:
+      - ./database:/app/database:rw
+      - ./uploads:/app/uploads:rw
+      - ./logs:/app/logs:rw
+
+  chibisafe-cdn:
+    restart: unless-stopped
+    container_name: chibisafe-cdn
+    image: nginx:latest
+    hostname: chibisafe-cdn
+    networks:
+      - traefik
+    labels:
+      traefik.enable: true
+
+			# HTTP Router
+      traefik.http.routers.chibisafe-cdn-http.entrypoints: web
+      traefik.http.routers.chibisafe-cdn-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file,cloudflarewarp@docker # Optional
+      traefik.http.routers.chibisafe-cdn-http.rule: Host(`cdn.your-domain-name.com`) # Make sure to set this as "Serve Uploads From" in settings later.
+      traefik.http.routers.chibisafe-cdn-http.service: chibisafe-cdn
+
+			# HTTPS Router (Secure)
+      traefik.http.routers.chibisafe-cdn.entrypoints: websecure
+      traefik.http.routers.chibisafe-cdn.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file,cloudflarewarp@docker # Optional
+      traefik.http.routers.chibisafe-cdn.rule: Host(`cdn.your-domain-name.com`) # Make sure to set this as "Serve Uploads From" in settings later.
+      traefik.http.routers.chibisafe-cdn.service: chibisafe-cdn
+      traefik.http.routers.chibisafe-cdn.tls.certresolver: cfdns # Alternatively, you can use letsencrypt
+      traefik.http.routers.chibisafe-cdn.tls.options: securetls@file
+
+      traefik.http.services.chibisafe-cdn.loadbalancer.server.port: 80
+    volumes:
+      - ./uploads:/usr/share/nginx/html:ro
+
+networks:
+  traefik:
+    external: true
+```
+
+## /path/to/traefik/dynamic.yml
+
+The config below includes the optional middleware defined in the `docker-compose.yml` above. You can find out more about the config file from the [official Traefik documentation](https://doc.traefik.io/traefik/middlewares/overview/#configuration-example).
+
+```yml
+tls:
+    options:
+        securetls:
+            minVersion: VersionTLS12
+            sniStrict: true
+            cipherSuites:
+                - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+                - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+
+http:
+    middlewares:
+        globalHeaders:
+            headers:
+                hostsProxyHeaders:
+                    - 'X-Forwarded-Host'
+                customResponseHeaders:
+                    server: ''
+                    x-xss-protection: ''
+                frameDeny: false
+                contentTypeNosniff: true
+        secureHeaders:
+            headers:
+                sslProxyHeaders:
+                    X-Forwarded-Proto: https
+        dropsecurityheaders:
+            headers:
+                accessControlAllowCredentials: 'true'
+                accessControlAllowHeaders: '*'
+                accessControlAllowMethods: '*'
+                accessControlAllowOriginList: '*'
+                accessControlExposeHeaders: '*'
+                accessControlMaxAge: '100000'
+                customresponseheaders:
+                    content-security-policy: ''
+                    cross-origin-opener-policy: ''
+                    permissions-policy: ''
+                    referrer-policy: ''
+                    x-frame-options: ''
+                    x-webkit-csp: ''
+        hsts:
+            headers:
+                stsSeconds: 63072000
+                stsIncludeSubdomains: true
+                stsPreload: true
+                forceSTSHeader: true
+        robotHeaders:
+            headers:
+                customResponseHeaders:
+                    X-Robots-Tag: 'none,noarchive,nosnippet,notranslate,noimageindex'
+    serversTransports:
+        skipverify:
+            insecureSkipVerify: true
+```
+
+## Run
+
+```bash
+docker network create traefik
+
+cd /path/to/chibisafe
+docker-compose up -d
+```


### PR DESCRIPTION
I run a server with Traefik, after running into numerous issues with Caddy I deemed it an unnecessary step.

This guide uses Traefik for routing and NGINX to serve uploads/files.