### PR TITLE
x-amz-acl header for DigitalOcean Spaces

### DIFF
--- a/packages/next/src/hooks/useUploadFile.ts
+++ b/packages/next/src/hooks/useUploadFile.ts
@@ -41,7 +41,7 @@ export const useUploadFile = ({ albumUuid }: { readonly albumUuid?: string | und
 
 			if (isNetworkStored) {
 				options.headers = {
-					'Content-Type': file.type,
+					'Content-Type': file.type
 				};
 
 				if(endpoint.includes("digitaloceanspaces.com")){

--- a/packages/next/src/hooks/useUploadFile.ts
+++ b/packages/next/src/hooks/useUploadFile.ts
@@ -42,8 +42,12 @@ export const useUploadFile = ({ albumUuid }: { readonly albumUuid?: string | und
 			if (isNetworkStored) {
 				options.headers = {
 					'Content-Type': file.type,
-          'x-amz-acl': 'public-read'
 				};
+
+				if(endpoint.includes("digitaloceanspaces.com")){
+					options.headers["x-amz-acl"] = "public-read";
+				}
+        
 			} else {
 				options.postParams = {
 					name: file.name,

--- a/packages/next/src/hooks/useUploadFile.ts
+++ b/packages/next/src/hooks/useUploadFile.ts
@@ -41,7 +41,8 @@ export const useUploadFile = ({ albumUuid }: { readonly albumUuid?: string | und
 
 			if (isNetworkStored) {
 				options.headers = {
-					'Content-Type': file.type
+					'Content-Type': file.type,
+          'x-amz-acl': 'public-read'
 				};
 			} else {
 				options.postParams = {


### PR DESCRIPTION
Digital ocean spaces require "x-amz-acl" header to be present if you want file to be public. I made this simple yet ugly change in order to be able to use DigitalOcean.

I know it looks bad, however there is no point doing this as a setting since this problem seems to be unique to DigitalOcean.