### PR TITLE
FIx: add file filtering for album

### DIFF
--- a/packages/backend/src/routes/album/GetAlbum.ts
+++ b/packages/backend/src/routes/album/GetAlbum.ts
@@ -42,11 +42,37 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 	const { uuid } = req.params as { uuid: string };
 
 	// Set up pagination options
-	const { page = 1, limit = 50 } = req.query as { limit?: number; page?: number };
+	const { page = 1, limit = 50, search = '' } = req.query as { limit?: number; page?: number; search?: string };
 	const options = {
 		take: limit,
 		skip: (page - 1) * limit
 	};
+
+	const dbSearchObject = search
+		? {
+				OR: [
+					{
+						name: {
+							contains: search
+						}
+					},
+					{
+						original: {
+							contains: search
+						}
+					},
+					{
+						tags: {
+							some: {
+								name: {
+									contains: search
+								}
+							}
+						}
+					}
+				]
+			}
+		: {};
 
 	// Make sure the uuid exists and it belongs to the user
 	const album = await prisma.albums.findFirst({
@@ -59,6 +85,7 @@ export const run = async (req: RequestWithUser, res: FastifyReply) => {
 			description: true,
 			nsfw: true,
 			files: {
+				where: dbSearchObject,
 				select: {
 					createdAt: true,
 					hash: true,


### PR DESCRIPTION
## Summary
- album search bar populates search param but doesn't filter files
- add file filtering based on implementation in `packages/backend/src/routes/files/GetFile.ts`