### PR TITLE
Feat/save duplicates to album

### DIFF
--- a/packages/backend/src/prisma/migrations/20250609000434_add_save_duplicates_to_album/migration.sql
+++ b/packages/backend/src/prisma/migrations/20250609000434_add_save_duplicates_to_album/migration.sql
@@ -1,0 +1,51 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_settings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "rateLimitWindow" INTEGER NOT NULL,
+    "rateLimitMax" INTEGER NOT NULL,
+    "secret" TEXT NOT NULL,
+    "serviceName" TEXT NOT NULL,
+    "chunkSize" TEXT NOT NULL,
+    "chunkedUploadsTimeout" INTEGER NOT NULL,
+    "maxSize" TEXT NOT NULL,
+    "generateZips" BOOLEAN NOT NULL,
+    "generateOriginalFileNameWithIdentifier" BOOLEAN NOT NULL DEFAULT false,
+    "generatedFilenameLength" INTEGER NOT NULL,
+    "generatedAlbumLength" INTEGER NOT NULL,
+    "generatedLinksLength" INTEGER NOT NULL DEFAULT 8,
+    "saveDuplicatesToAlbum" BOOLEAN NOT NULL DEFAULT false,
+    "blockedExtensions" TEXT NOT NULL,
+    "blockNoExtension" BOOLEAN NOT NULL,
+    "publicMode" BOOLEAN NOT NULL,
+    "userAccounts" BOOLEAN NOT NULL,
+    "disableStatisticsCron" BOOLEAN NOT NULL,
+    "disableUpdateCheck" BOOLEAN NOT NULL DEFAULT false,
+    "backgroundImageURL" TEXT NOT NULL,
+    "logoURL" TEXT NOT NULL,
+    "metaDescription" TEXT NOT NULL,
+    "metaKeywords" TEXT NOT NULL,
+    "metaTwitterHandle" TEXT NOT NULL,
+    "metaDomain" TEXT NOT NULL DEFAULT '',
+    "serveUploadsFrom" TEXT NOT NULL DEFAULT '',
+    "enableMixedCaseFilenames" BOOLEAN NOT NULL DEFAULT true,
+    "usersStorageQuota" TEXT NOT NULL DEFAULT '0',
+    "useNetworkStorage" BOOLEAN NOT NULL DEFAULT false,
+    "useMinimalHomepage" BOOLEAN NOT NULL DEFAULT false,
+    "useUrlShortener" BOOLEAN NOT NULL DEFAULT false,
+    "generateThumbnails" BOOLEAN NOT NULL DEFAULT true,
+    "privacyPolicyPageContent" TEXT NOT NULL DEFAULT '',
+    "termsOfServicePageContent" TEXT NOT NULL DEFAULT '',
+    "rulesPageContent" TEXT NOT NULL DEFAULT '',
+    "S3Region" TEXT NOT NULL DEFAULT '',
+    "S3Bucket" TEXT NOT NULL DEFAULT '',
+    "S3AccessKey" TEXT NOT NULL DEFAULT '',
+    "S3SecretKey" TEXT NOT NULL DEFAULT '',
+    "S3Endpoint" TEXT NOT NULL DEFAULT '',
+    "S3PublicUrl" TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO "new_settings" ("S3AccessKey", "S3Bucket", "S3Endpoint", "S3PublicUrl", "S3Region", "S3SecretKey", "backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "disableUpdateCheck", "enableMixedCaseFilenames", "generateOriginalFileNameWithIdentifier", "generateThumbnails", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "generatedLinksLength", "id", "logoURL", "maxSize", "metaDescription", "metaDomain", "metaKeywords", "metaTwitterHandle", "privacyPolicyPageContent", "publicMode", "rateLimitMax", "rateLimitWindow", "rulesPageContent", "secret", "serveUploadsFrom", "serviceName", "termsOfServicePageContent", "useMinimalHomepage", "useNetworkStorage", "useUrlShortener", "userAccounts", "usersStorageQuota") SELECT "S3AccessKey", "S3Bucket", "S3Endpoint", "S3PublicUrl", "S3Region", "S3SecretKey", "backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "disableUpdateCheck", "enableMixedCaseFilenames", "generateOriginalFileNameWithIdentifier", "generateThumbnails", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "generatedLinksLength", "id", "logoURL", "maxSize", "metaDescription", "metaDomain", "metaKeywords", "metaTwitterHandle", "privacyPolicyPageContent", "publicMode", "rateLimitMax", "rateLimitWindow", "rulesPageContent", "secret", "serveUploadsFrom", "serviceName", "termsOfServicePageContent", "useMinimalHomepage", "useNetworkStorage", "useUrlShortener", "userAccounts", "usersStorageQuota" FROM "settings";
+DROP TABLE "settings";
+ALTER TABLE "new_settings" RENAME TO "settings";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -133,6 +133,7 @@ model settings {
 	generatedFilenameLength Int
 	generatedAlbumLength Int
 	generatedLinksLength Int @default(8)
+	saveDuplicatesToAlbum Boolean @default(false)
 	blockedExtensions String
 	blockNoExtension Boolean
 	publicMode Boolean

--- a/packages/backend/src/structures/interfaces.ts
+++ b/packages/backend/src/structures/interfaces.ts
@@ -139,6 +139,7 @@ export interface Settings {
 	rateLimitMax: number;
 	rateLimitWindow: number;
 	rulesPageContent: string;
+	saveDuplicatesToAlbum: boolean;
 	secret: string;
 	serveUploadsFrom: string;
 	serviceName: string;

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -77,6 +77,7 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.privacyPolicyPageContent = settingsTable.privacyPolicyPageContent;
 		SETTINGS.termsOfServicePageContent = settingsTable.termsOfServicePageContent;
 		SETTINGS.rulesPageContent = settingsTable.rulesPageContent;
+		SETTINGS.saveDuplicatesToAlbum = settingsTable.saveDuplicatesToAlbum
 		return;
 	}
 
@@ -122,7 +123,8 @@ export const loadSettings = async (force = false) => {
 		S3PublicUrl: '',
 		privacyPolicyPageContent: '',
 		termsOfServicePageContent: '',
-		rulesPageContent: ''
+		rulesPageContent: '',
+		saveDuplicatesToAlbum: false
 	};
 
 	await prisma.settings.create({
@@ -250,6 +252,12 @@ const SETTINGS_META = {
 		name: 'Generated short URL Length',
 		notice: 'This setting should at least be 8 characters long to avoid collisions.',
 		category: 'other'
+	},
+	saveDuplicatesToAlbum: {
+		type: 'boolean',
+		description: 'Whether or not to add a file that was already uploaded to the album you tried uploading it to.',
+		name: 'Add duplicates to Album',
+		category: 'uploads'
 	},
 	blockedExtensions: {
 		type: 'string',
@@ -407,12 +415,6 @@ const SETTINGS_META = {
 		type: 'text',
 		description: 'The markdown content for the terms of service page. Leave empty to disable.',
 		name: 'Terms of Service Page',
-		category: 'legal'
-	},
-	rulesPageContent: {
-		type: 'text',
-		description: 'The markdown content for the rules page. Leave empty to disable.',
-		name: 'Rules Page',
 		category: 'legal'
 	}
 };

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -416,5 +416,11 @@ const SETTINGS_META = {
 		description: 'The markdown content for the terms of service page. Leave empty to disable.',
 		name: 'Terms of Service Page',
 		category: 'legal'
+	},
+	rulesPageContent: {
+		type: 'text',
+		description: 'The markdown content for the rules page. Leave empty to disable.',
+		name: 'Rules Page',
+		category: 'legal'
 	}
 };

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -51,6 +51,7 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.generatedFilenameLength = settingsTable.generatedFilenameLength;
 		SETTINGS.generatedAlbumLength = settingsTable.generatedAlbumLength;
 		SETTINGS.generatedLinksLength = settingsTable.generatedLinksLength;
+		SETTINGS.saveDuplicatesToAlbum = settingsTable.saveDuplicatesToAlbum;
 		SETTINGS.blockedExtensions = settingsTable.blockedExtensions.split(',');
 		SETTINGS.blockNoExtension = settingsTable.blockNoExtension;
 		SETTINGS.publicMode = settingsTable.publicMode;
@@ -77,7 +78,6 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.privacyPolicyPageContent = settingsTable.privacyPolicyPageContent;
 		SETTINGS.termsOfServicePageContent = settingsTable.termsOfServicePageContent;
 		SETTINGS.rulesPageContent = settingsTable.rulesPageContent;
-		SETTINGS.saveDuplicatesToAlbum = settingsTable.saveDuplicatesToAlbum
 		return;
 	}
 
@@ -98,6 +98,7 @@ export const loadSettings = async (force = false) => {
 		generatedFilenameLength: 12,
 		generatedAlbumLength: 6,
 		generatedLinksLength: 8,
+		saveDuplicatesToAlbum: false,
 		blockedExtensions: ['.jar', '.exe', '.msi', '.com', '.bat', '.cmd', '.scr', '.ps1', '.sh'].join(','),
 		blockNoExtension: true,
 		publicMode: false,
@@ -123,8 +124,7 @@ export const loadSettings = async (force = false) => {
 		S3PublicUrl: '',
 		privacyPolicyPageContent: '',
 		termsOfServicePageContent: '',
-		rulesPageContent: '',
-		saveDuplicatesToAlbum: false
+		rulesPageContent: ''
 	};
 
 	await prisma.settings.create({

--- a/packages/backend/src/utils/File.ts
+++ b/packages/backend/src/utils/File.ts
@@ -518,17 +518,13 @@ export const handleUploadFile = async ({
 	let uploadedFile;
 	const fileOnDb = await checkFileHashOnDB(user, file);
 	if (fileOnDb?.repeated) {
-
-		log.info(
-			`> Tried uploading ${file.original} but already exists on database with identifier: ${fileOnDb.file.name}`
-		);
-
-		//  && album != fileOnDb.file.albums.find((file: any) => file.id === album)
-		// todo what happens if the file is already in the same album
-		if(SETTINGS.saveDuplicatesToAlbum && album) {
-			await saveFileToAlbum(album, fileOnDb.file.id)
+		if (SETTINGS.saveDuplicatesToAlbum && album) {
+			await saveFileToAlbum(album, fileOnDb.file.id);
+		} else {
+			log.info(
+				`> Tried uploading ${file.original} but already exists on database with identifier: ${fileOnDb.file.name}. Consider enabling "Add duplicates to Album"`
+			);
 		}
-
 
 		uploadedFile = fileOnDb.file;
 		await deleteTmpFile(upload.path);

--- a/packages/backend/src/utils/File.ts
+++ b/packages/backend/src/utils/File.ts
@@ -518,9 +518,18 @@ export const handleUploadFile = async ({
 	let uploadedFile;
 	const fileOnDb = await checkFileHashOnDB(user, file);
 	if (fileOnDb?.repeated) {
+
 		log.info(
 			`> Tried uploading ${file.original} but already exists on database with identifier: ${fileOnDb.file.name}`
 		);
+
+		//  && album != fileOnDb.file.albums.find((file: any) => file.id === album)
+		// todo what happens if the file is already in the same album
+		if(SETTINGS.saveDuplicatesToAlbum && album) {
+			await saveFileToAlbum(album, fileOnDb.file.id)
+		}
+
+
 		uploadedFile = fileOnDb.file;
 		await deleteTmpFile(upload.path);
 	} else {

--- a/packages/next/src/components/forms/SettingsForm.tsx
+++ b/packages/next/src/components/forms/SettingsForm.tsx
@@ -51,7 +51,7 @@ const formSchema = z.object({
 	generateOriginalFileNameWithIdentifier: z.boolean().optional(),
 	enableMixedCaseFilenames: z.boolean().optional(),
 	generatedFilenameLength: z.coerce.number(),
-  saveDuplicatesToAlbum: z.boolean().optional(),
+	saveDuplicatesToAlbum: z.boolean().optional(),
 	blockedExtensions: z.string().optional(),
 	blockNoExtension: z.boolean().optional(),
 	useNetworkStorage: z.boolean().optional(),

--- a/packages/next/src/components/forms/SettingsForm.tsx
+++ b/packages/next/src/components/forms/SettingsForm.tsx
@@ -51,6 +51,7 @@ const formSchema = z.object({
 	generateOriginalFileNameWithIdentifier: z.boolean().optional(),
 	enableMixedCaseFilenames: z.boolean().optional(),
 	generatedFilenameLength: z.coerce.number(),
+  saveDuplicatesToAlbum: z.boolean().optional(),
 	blockedExtensions: z.string().optional(),
 	blockNoExtension: z.boolean().optional(),
 	useNetworkStorage: z.boolean().optional(),


### PR DESCRIPTION
I commission a lot of art. I mainly use chibisafe to manage the references I send to an artist. For that, I create an album that contains every image I plan to use as reference.

Currently, a file won't be added to an album when uploaded if it already exists. That was incredibly confusing at the beginning and mostly annoying now cause I have to slightly crop the image every time I want to upload it to an album.

This Pull request adds an option to the settings (which is disabled by default), which makes it so that the (already existing) file gets added to the new album.

---
In the future, it might be useful to only delete a file when deleting an album using "delete album and files" when it isn't in more than one album. Currently a file gets deleted (and therefore removed from every album it's in), which can also cause confusion. If desired, I will make another pull request adding this feature.