### PR TITLE
feat: path style bucket setting for s3

### DIFF
--- a/packages/backend/src/prisma/migrations/20250705131250_add_s3pathstyle_setting/migration.sql
+++ b/packages/backend/src/prisma/migrations/20250705131250_add_s3pathstyle_setting/migration.sql
@@ -1,0 +1,51 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_settings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "rateLimitWindow" INTEGER NOT NULL,
+    "rateLimitMax" INTEGER NOT NULL,
+    "secret" TEXT NOT NULL,
+    "serviceName" TEXT NOT NULL,
+    "chunkSize" TEXT NOT NULL,
+    "chunkedUploadsTimeout" INTEGER NOT NULL,
+    "maxSize" TEXT NOT NULL,
+    "generateZips" BOOLEAN NOT NULL,
+    "generateOriginalFileNameWithIdentifier" BOOLEAN NOT NULL DEFAULT false,
+    "generatedFilenameLength" INTEGER NOT NULL,
+    "generatedAlbumLength" INTEGER NOT NULL,
+    "generatedLinksLength" INTEGER NOT NULL DEFAULT 8,
+    "blockedExtensions" TEXT NOT NULL,
+    "blockNoExtension" BOOLEAN NOT NULL,
+    "publicMode" BOOLEAN NOT NULL,
+    "userAccounts" BOOLEAN NOT NULL,
+    "disableStatisticsCron" BOOLEAN NOT NULL,
+    "disableUpdateCheck" BOOLEAN NOT NULL DEFAULT false,
+    "backgroundImageURL" TEXT NOT NULL,
+    "logoURL" TEXT NOT NULL,
+    "metaDescription" TEXT NOT NULL,
+    "metaKeywords" TEXT NOT NULL,
+    "metaTwitterHandle" TEXT NOT NULL,
+    "metaDomain" TEXT NOT NULL DEFAULT '',
+    "serveUploadsFrom" TEXT NOT NULL DEFAULT '',
+    "enableMixedCaseFilenames" BOOLEAN NOT NULL DEFAULT true,
+    "usersStorageQuota" TEXT NOT NULL DEFAULT '0',
+    "useNetworkStorage" BOOLEAN NOT NULL DEFAULT false,
+    "useMinimalHomepage" BOOLEAN NOT NULL DEFAULT false,
+    "useUrlShortener" BOOLEAN NOT NULL DEFAULT false,
+    "generateThumbnails" BOOLEAN NOT NULL DEFAULT true,
+    "privacyPolicyPageContent" TEXT NOT NULL DEFAULT '',
+    "termsOfServicePageContent" TEXT NOT NULL DEFAULT '',
+    "rulesPageContent" TEXT NOT NULL DEFAULT '',
+    "S3Region" TEXT NOT NULL DEFAULT '',
+    "S3Bucket" TEXT NOT NULL DEFAULT '',
+    "S3AccessKey" TEXT NOT NULL DEFAULT '',
+    "S3SecretKey" TEXT NOT NULL DEFAULT '',
+    "S3Endpoint" TEXT NOT NULL DEFAULT '',
+    "S3PathStyle" BOOLEAN NOT NULL DEFAULT false,
+    "S3PublicUrl" TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO "new_settings" ("S3AccessKey", "S3Bucket", "S3Endpoint", "S3PublicUrl", "S3Region", "S3SecretKey", "backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "disableUpdateCheck", "enableMixedCaseFilenames", "generateOriginalFileNameWithIdentifier", "generateThumbnails", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "generatedLinksLength", "id", "logoURL", "maxSize", "metaDescription", "metaDomain", "metaKeywords", "metaTwitterHandle", "privacyPolicyPageContent", "publicMode", "rateLimitMax", "rateLimitWindow", "rulesPageContent", "secret", "serveUploadsFrom", "serviceName", "termsOfServicePageContent", "useMinimalHomepage", "useNetworkStorage", "useUrlShortener", "userAccounts", "usersStorageQuota") SELECT "S3AccessKey", "S3Bucket", "S3Endpoint", "S3PublicUrl", "S3Region", "S3SecretKey", "backgroundImageURL", "blockNoExtension", "blockedExtensions", "chunkSize", "chunkedUploadsTimeout", "disableStatisticsCron", "disableUpdateCheck", "enableMixedCaseFilenames", "generateOriginalFileNameWithIdentifier", "generateThumbnails", "generateZips", "generatedAlbumLength", "generatedFilenameLength", "generatedLinksLength", "id", "logoURL", "maxSize", "metaDescription", "metaDomain", "metaKeywords", "metaTwitterHandle", "privacyPolicyPageContent", "publicMode", "rateLimitMax", "rateLimitWindow", "rulesPageContent", "secret", "serveUploadsFrom", "serviceName", "termsOfServicePageContent", "useMinimalHomepage", "useNetworkStorage", "useUrlShortener", "userAccounts", "usersStorageQuota" FROM "settings";
+DROP TABLE "settings";
+ALTER TABLE "new_settings" RENAME TO "settings";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -160,6 +160,7 @@ model settings {
 	S3AccessKey String @default("")
 	S3SecretKey String @default("")
 	S3Endpoint String @default("")
+	S3PathStyle Boolean @default(false)
 	S3PublicUrl String @default("")
 }
 

--- a/packages/backend/src/structures/interfaces.ts
+++ b/packages/backend/src/structures/interfaces.ts
@@ -109,6 +109,7 @@ export interface Settings {
 	S3AccessKey: string;
 	S3Bucket: string;
 	S3Endpoint: string;
+	S3PathStyle: boolean;
 	S3PublicUrl: string;
 	S3Region: string;
 	S3SecretKey: string;

--- a/packages/backend/src/structures/s3.ts
+++ b/packages/backend/src/structures/s3.ts
@@ -7,7 +7,8 @@ export const createS3Client = () => {
 		credentials: {
 			accessKeyId: SETTINGS.S3AccessKey,
 			secretAccessKey: SETTINGS.S3SecretKey
-		}
+		},
+		forcePathStyle: SETTINGS.S3PathStyle
 	};
 
 	if (SETTINGS.S3Endpoint) {

--- a/packages/backend/src/structures/settings.ts
+++ b/packages/backend/src/structures/settings.ts
@@ -73,6 +73,7 @@ export const loadSettings = async (force = false) => {
 		SETTINGS.S3AccessKey = settingsTable.S3AccessKey;
 		SETTINGS.S3SecretKey = settingsTable.S3SecretKey;
 		SETTINGS.S3Endpoint = settingsTable.S3Endpoint;
+		SETTINGS.S3PathStyle = settingsTable.S3PathStyle;
 		SETTINGS.S3PublicUrl = settingsTable.S3PublicUrl;
 		SETTINGS.privacyPolicyPageContent = settingsTable.privacyPolicyPageContent;
 		SETTINGS.termsOfServicePageContent = settingsTable.termsOfServicePageContent;
@@ -118,6 +119,7 @@ export const loadSettings = async (force = false) => {
 		S3Bucket: '',
 		S3AccessKey: '',
 		S3SecretKey: '',
+		S3PathStyle: false,
 		S3Endpoint: '',
 		S3PublicUrl: '',
 		privacyPolicyPageContent: '',
@@ -376,6 +378,13 @@ const SETTINGS_META = {
 		type: 'string',
 		description: 'The secret key for the S3 bucket.',
 		name: 'S3 Secret Key',
+		category: 'uploads'
+	},
+	S3PathStyle: {
+		type: 'boolean',
+		description: 'Whether or not to use path style access for the S3 bucket',
+		name: 'S3 Path Style',
+		notice: 'This is usually true for non-AWS S3 providers.',
 		category: 'uploads'
 	},
 	S3Endpoint: {

--- a/packages/next/src/components/forms/SettingsForm.tsx
+++ b/packages/next/src/components/forms/SettingsForm.tsx
@@ -59,6 +59,7 @@ const formSchema = z.object({
 	S3Bucket: z.string().optional(),
 	S3AccessKey: z.string().optional(),
 	S3SecretKey: z.string().optional(),
+	S3PathStyle: z.boolean().optional(),
 	S3Endpoint: z.string().optional(),
 	S3PublicUrl: z.string().optional(),
 	// Other


### PR DESCRIPTION
Added a simple toggle to the settings to enable path style buckets when using s3 for storage, allows usage of several S3 compatible storage solutions.